### PR TITLE
Remove allof hasExtensions from Descriptor

### DIFF
--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -290,8 +290,6 @@ components:
       type: object
     Descriptor: 
       example: '{ "endpoints": [ { "protocolInformation": { "endpointAddress": "https://localhost:1234", "endpointProtocolVersion": "1.1" }, "interface": "AAS-1.0" }, { "protocolInformation": { "endpointAddress": "opc.tcp://localhost:4840" }, "interface": "AAS-1.0" }, { "protocolInformation": { "endpointAddress": "https://localhost:5678", "endpointProtocolVersion": "1.1", "subprotocol": "OPC UA Basic SOAP", "subprotocolBody": "ns=2;s=MyAAS", "subprotocolBodyEncoding": "application/soap+xml" }, "interface": "AAS-1.0" } ] }'
-      allOf:
-        - $ref: "https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.0#/components/schemas/HasExtensions"
       properties: 
         description: 
           type: array


### PR DESCRIPTION
Solves #99 

The current state is technically not wrong as the attribute `extensions` is declared twice (once directly at the Discriptor and once in the HasExtensions) but exactly in the same manner. That's why I didn't increase the version to `V3.0.1`.
However, it should not be declared in such redundant manner, of course. 

Long story short: I don't regard this one as a bugfix but we should change it nevertheless.