### PR TITLE
Edit issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template-for-bugs.md
+++ b/.github/ISSUE_TEMPLATE/issue-template-for-bugs.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Template for Bug Reports
 about: Describe this issue's purpose here.
-title: '[BUG] Replace Title'
+title: 'Replace Title'
 labels: 'bug'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/issue-template-for-feature-requests.md
+++ b/.github/ISSUE_TEMPLATE/issue-template-for-feature-requests.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Template for Requesting new AAS API Features
 about: Describe this issue's purpose here.
-title: '[Feat. Req.] Replace Title'
+title: 'Replace Title'
 labels: 'enhancement'
 assignees: ''
 


### PR DESCRIPTION
Remove [Bug] and [Feat. Req.] from title
This was necessary because we use `bug` and `enhancement` label
