### PR TITLE
Remove Category, semanticId only ExternalReference

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/Annex/IDTA-01002_SerializationModifierExamples.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/Annex/IDTA-01002_SerializationModifierExamples.adoc
@@ -56,10 +56,9 @@ If applied to the Submodel:
     "value": [ {
         "modelType": "Property",
         "idShort": "MaxRotationSpeed",
-        "category": "PARAMETER",
         "semanticId": {
           "keys": [ {
-              "type": "ConceptDescription",
+              "type": "GlobalReference",
               "value": "0173-1#02-BAA120#008"
           } ],
           "type": "ExternalReference"


### PR DESCRIPTION
a) removed Category from example since deprecated
b) change ConceptDescription to GlobalReference since only external references allowed for semanticId with V3.1