### PR TITLE
Revert "Change to V3.0.3"

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
@@ -6,7 +6,7 @@
 This specification is part of the https://industrialdigitaltwin.org/en/content-hub/aasspecifications[Asset Administration Shell Specification series].
 ====
 
-NOTE: We do not provide a web version of the specification for version 3.0.3
+NOTE: We do not provide a web version of the specification for version 3.0.2.
 Please download and use the PDF version of the document instead.
 
-link:https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2024/10/IDTA-01002-3-0-3_SpecificationAssetAdministrationShell_Part2_API.pdf[Download the specification in PDF format]
+link:https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2024/06/IDTA-01002-3-0-2_SpecificationAssetAdministrationShell_Part2_API.pdf[Download the specification in PDF format]


### PR DESCRIPTION
Reverts admin-shell-io/aas-specs-api#331

This PR affects a branch used only for a note in the web documentation, indicating that Version V3.0.2 has no web documentation, and users should refer to the PDF documentation.

In #331, the note was updated to Version V3.0.3. However, this change should apply to the branch for V3.0.3, which has not yet been created.
This PR reverts the note back to V3.0.2 to ensure accuracy for the current version.