### PR TITLE
Update cardinality for Discovery Interface

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -1783,7 +1783,7 @@ It is the predefined key “_globalAssetId_” that would refer to the _AssetInf
 ====
 
 
-|yes |SpecificAssetId |1
+|yes |SpecificAssetId |1..*
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |Asset identifier created successfully |yes |SpecificAssetId |1


### PR DESCRIPTION
The Discovery Interface allows for multiple Specific Asset Ids, thus the specification for the operation should reflect that.
I believe this was a typo in the specification as it is reflected in the swagger api https://app.swaggerhub.com/apis/Plattform_i40/DiscoveryServiceSpecification/V3.0_SSP-001#/Asset%20Administration%20Shell%20Basic%20Discovery%20API/PostAllAssetLinksById 