### PR TITLE
Changed Endpoint Examples and Conformance + editorial changes

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -46,7 +46,7 @@ AAS Repository,
 
 Submodel Repository, 
 
-Concept Description Repository | New a| Newly introduced API operations for querying 
+Concept Description Repository | Extended a| Newly introduced API operations for querying 
 | | AAS Basic Discovery | Changed a| deprecate GetAllAssetAdministrationShellIdsByAssetLink  
 
 add SearchAllAssetAdministrationShellIdsByAssetLink
@@ -60,7 +60,7 @@ Changed the parameter assetIds from `mandatory` to `optional`.
 OpenAPI remains unchanged. 
 (https://github.com/admin-shell-io/aas-specs-api/issues/301[#301])
 
-| |AAS  Registry  | Changed a| add CreateBulkAssetAdministrationShellDescriptors
+| |AAS  Registry  | Extended a| add CreateBulkAssetAdministrationShellDescriptors
 
 add PutBulkAssetAdministrationShellDescriptorsById
 
@@ -68,7 +68,7 @@ add DeleteBulkAssetAdministrationShellDescriptorsById
 
 
 
-| | Submodel Registry | Changed a| add PostBulkSubmodelDescriptors,
+| | Submodel Registry | Extended a| add PostBulkSubmodelDescriptors,
 
 add PutBulkSubmodelDescriptorsById,
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -113,9 +113,9 @@ h|Profile h|Kind of Change h|Comment
  |Asset Administration Shell Registry Profile - Bulk Profile |new a| 
  |Submodel Registry Profile - Bulk Profile |new a| 
  |Discovery Profile - Full Profile |update a|
- GetAllAssetAdministrationShellIdsByAssetLink set to deprecated  
+GetAllAssetAdministrationShellIdsByAssetLink set to deprecated  
  
- added new API-operation SearchAllAssetAdministrationShellIdsByAssetLink
+added new API-operation SearchAllAssetAdministrationShellIdsByAssetLink
  |Discovery Profile - Read Profile |new a|
 |===
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -68,9 +68,9 @@ add DeleteBulkAssetAdministrationShellDescriptorsById
 
 
 
-| | Submodel Registry | Extended a| add PostBulkSubmodelDescriptors,
+| | Submodel Registry | Extended a| add PostBulkSubmodelDescriptors
 
-add PutBulkSubmodelDescriptorsById,
+add PutBulkSubmodelDescriptorsById
 
 add DeleteBulkSubmodelDescriptorsById
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/general.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/general.adoc
@@ -324,7 +324,7 @@ The example of a device or container containing one AAS with its related submode
 Note: identifiers are base64url-encoded in the API, i.e. \{aas-identifier} and [.green]#\{submodel-identifier}#. [.blue]#The \{idShortPath} is URL-encoded in the API#.
 ====
 
-
+[[#query-language]]
 == Query Language
 
 Many use cases of the Asset Administration Shell require the involvement of a high number of Asset Administration Shells at the same time. Executing the business logic on all potentially involved Asset Administration Shells solely by the client application requires a huge amount of transferred data objects and bandwidth. It is therefore necessary to send parts of the selection conditions to the AAS hosting systems. The AAS Query Language enables AAS clients to describe and handover their interests and AAS servers to only respond with the needed data objects.
@@ -336,7 +336,7 @@ Note: The AAS Query Language and the AAS Access Rules xref:bibliography.adoc#bib
 ====
 
 
-== Use Case Examples
+=== Use Case Examples
 
 Examples for Use Cases are search queries in the submodels DigitalNameplate, TechnicalData or HandoverDocumentation. +
 DigitalNameplate has a fixed structure, only the bottom part with Markings and AssetSpecificProperties is variable. Queries in DigitalNameplate can be well done by providing idShortPaths to the elements in the query, e.g. searching for all DigitalNameplates with a certain ManufacturerName and CountryOfOrigin. +
@@ -370,6 +370,7 @@ AAS consists of a hierarchical structure. An AAS references its "contained" subm
 The query language allows to both address a specific instance of the data or to search all data in a repository. A specific instance is addressed by specifying the id of an Identifiable and the idShortPath to a Referable in a Submodel. +
 If such explicit information is not specified, a hierarchical search is made. By the $aas FieldIdentifier conditions for all the relevant AAS are defined. By the $sm FieldIdentifier conditions for all the relevant submodels are defined. $sm can be used with and without $aas. If $aas and $sm are used together, only the submodels referenced by the matching $aas are searched by the $sm expression. The same search principle is used, when combining $sm and $sme. In such case only the SubmodelElements which are part of matching submodels by $sm expression are searched by the $sme expression. Several such hierarchical conditions may even be combined by $match expressions.
 
+[[#query-grammar]]
 === Grammar
 
 The content and structure of the AAS Query Language is defined in the context-free Backus-Naur form (BNF). See Appendix xref:annex/backus-naur-form.adoc[Backus-Naur-Form] for more details on BNF. The detailed serialisation and interaction patterns are defined by the different technology mappings, e.g., the AAS HTTP API represents AAS Queries as JSON objects (see Clause xref:http-rest-api/http-rest-api.adoc#query-json-serialisation[Serialisation]). Other mappings may define different serialisations, however, all have to follow the general structure of queries defined in the following grammar.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -10,7 +10,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 include::../includes/special-parameters.adoc[]
 
-
+[[#service-specifications-and-profiles]]
 = Service Specifications and Profiles
 
 xref:general.adoc#i40-service-model[Figure in Clause General] defines that a service specification contains at least one API and that an API contains at least one API Operation.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -45,6 +45,7 @@ x: Service Specification contains API at the root
 
 s: Service Specification contains API through superpaths as introduced in Clause 0
 
+[[#profiles]]
 == Profiles
 
 Service specifications are further refined in profiles, governing which API operations, modifiers, and path combinations are supported.
@@ -67,6 +68,7 @@ Additional profiles might be introduced in future versions of this document.
 Note: in the following, only the last part (<name of service specification>/SSP-<profile number>) is used in the text for better readability, e.g. “AssetAdministrationShellServiceSpecification/SSP-001” instead of “https://admin-shell.io/aas/API/3/0/AssetAdministrationShellServiceSpecification/SSP-001”.
 ====
 
+[[#asset-administration-shell-service-specification]]
 == Asset Administration Shell Service Specification
 
 [%autowidth,width="100%",cols="45%,55%",options="header",]
@@ -76,6 +78,7 @@ h|Service Specification / Profiles h|Description
 |AssetAdministrationShellServiceSpecification/SSP-002 |Only read operations; is included in the profile AssetAdministrationShellServiceSpecification/SSP-001.
 |===
 
+[[#asset-administration-shell-service-specification-SSP-001]]
 === Asset Administration Shell Service Specification – Full Profile
 
 The Asset Administration Shell service specification with all its features and endpoints is represented through the profile identifier *AssetAdministrationShellServiceSpecification/SSP-001*:
@@ -136,6 +139,7 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellServiceSpecification/V3.1_SSP-001
 
+[[#asset-administration-shell-service-specification-SSP-002]]
 === Asset Administration Shell Service Specification – Read Profile
 
 The Asset Administration Shell Service specification with the minimal feature set is represented through *AssetAdministrationShellServiceSpecification/SSP-002*:
@@ -174,6 +178,7 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellServiceSpecification/V3.0_SPP-002[https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellServiceSpecification/V3.1_SSP-002]
 
+[[#submodel-service-specification]]
 == Submodel Service Specification
 
 [%autowidth,width="100%",options="header",]
@@ -184,6 +189,7 @@ h|Service Specification / Profiles |Description
 |SubmodelServiceSpecification/SSP-003 |Limitation on the basic capabilities plus the option to execute synchronous operations and to read the submodel in the ValueOnly-serialization format to reduce required bandwidth; is included in the profile SubmodelServiceSpecification/SSP-001.
 |===
 
+[[#submodel-service-specification-SSP-001]]
 === Submodel Service Specification – Full Profile 
 
 The submodel service specification with all its features and endpoints is represented through *SubmodelServiceSpecification/SSP-001*:
@@ -232,6 +238,7 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelServiceSpecification/V3.1_SSP-001
 
+[[#submodel-service-specification-SSP-002]]
 === Submodel Service Specification – Read Profile
 
 The submodel service specification with its minimal feature set is represented through *SubmodelServiceSpecification/SSP-002*:
@@ -267,6 +274,7 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelServiceSpecification/V3.0_SPP-002[https://app.swaggerhub.com/apis/Plattform_i40/SubmodelServiceSpecification/V3.1_SSP-002]
 
+[[#submodel-service-specification-SSP-003]]
 === Submodel Service Specification – Value Profile 
 
 The submodel service specification with a reduced feature set is represented through *SubmodelServiceSpecification/SSP-003*:

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
@@ -64,3 +64,7 @@ Version 1.0 RC01 of this document was developed from December 2019 to November 2
 This document is Part 2 of the document series “Specification of the Asset Administration Shell”.
 
 This specification is versioned using Semantic Versioning 2.0.0 and follows the semver specification xref:bibliography.adoc#bib9[[9\]].
+
+include::./shared/versioning.adoc[]
+
+include::./shared/conformance.adoc[]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/shared/conformance.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/shared/conformance.adoc
@@ -1,0 +1,27 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/).
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
+
+
+=== Conformance
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in https://tools.ietf.org/html/bcp14[BCP 14] https://tools.ietf.org/html/rfc2119[RFC2119] https://tools.ietf.org/html/rfc8174[RFC8174]footnote:[https://www.ietf.org/rfc/rfc2119.txt]:
+
+* MUST word, or the terms "REQUIRED" or "SHALL", mean that the definition is an absolute requirement of the specification.
+* MUST NOT This phrase, or the phrase "SHALL NOT", mean that the definition is an absolute prohibition of the specification.
+* SHOULD This word, or the adjective "RECOMMENDED", mean that there may exist valid reasons in particular circumstances to ignore a particular item, but the full implications must be understood and carefully weighed before choosing a different course.
+* SHOULD NOT This phrase, or the phrase "NOT RECOMMENDED" mean that there may exist valid reasons in particular circumstances when the particular behavior is acceptable or even useful, but the full implications should be understood and the case carefully weighed before implementing any behavior described with this label.
+* MAY This word, or the adjective "OPTIONAL", mean that an item is truly optional.
+One vendor may choose to include the item because a particular marketplace requires it or because the vendor feels that it enhances the product while another vendor may omit the same item.
+An implementation which does not include a particular option MUST be prepared to interoperate with another implementation which does include the option, though perhaps with reduced functionality.
+In the same vein an implementation which does include a particular option MUST be prepared to interoperate with another implementation which does not include the option (except, of course, for the feature the option provides.)
+
+

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/shared/versioning.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/shared/versioning.adoc
@@ -1,0 +1,18 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/).
+
+SPDX-License-Identifier: CC-BY-4.0
+
+Illustrations:
+Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, designed by Publik. Agentur für Kommunikation GmbH
+////
+
+
+=== Versioning
+
+This specification is versioned using link:https://semver.org/spec/v2.0.0.html[Semantic Versioning 2.0.0] (semver) and follows the semver specification xref:bibliography.adoc#bib9[[9\]].
+
+

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -132,41 +132,55 @@ h|*Interface* h|*interface-shortName*
 |Asset Administration Shell Basic Discovery Interface |AAS-DISCOVERY
 |===
 
-The value for the interface attribute is “\{interface-shortName}-\{interface-version}”.
+The value for the interface attribute shall be “\{interface-shortName}-\{interface-version}”.
 
-The interface-version of this specification is “3.0”, e.g. the entry for the Asset Administration Shell Interface is “AAS-3.0”.
+The interface-version of this specification is “3.1”, e.g. the entry for the Asset Administration Shell Interface is “AAS-3.1”.
 
-See the following example for a descriptor with several endpoints:
+See the following example for descriptor endpoints:
 
 [source,json,linenums]
 ----
-{
   "endpoints": [
     {
       "protocolInformation": {
         "endpointAddress": "https://localhost:1234",
         "endpointProtocolVersion": "1.1"
       },
-      "interface": "AAS-3.0"
+      "interface": "SUBMODEL-3.1"
     },
-    {
+	{
       "protocolInformation": {
-        "endpointAddress": "opc.tcp://localhost:4840"
+        "endpointAddress": "https://localhost:1234",
+        "endpointProtocolVersion": "1.1"
       },
-      "interface": "AAS-3.0"
-    },
-    {
-      "protocolInformation": {
-        "endpointAddress": "https://localhost:5678",
-        "endpointProtocolVersion": "1.1",
-        "subprotocol": "OPC UA Basic SOAP",
-        "subprotocolBody": "ns=2;s=MyAAS",
-        "subprotocolBodyEncoding": "application/soap+xml"
-      },
-      "interface": "AAS-3.0"
+      "interface": "SUBMODEL-2.0"
     }
-  ]
-}
+ ]
+----
+
+In the following example from the link:https://eclipse-tractusx.github.io/docs-kits/kits/Digital%20Twin%20Kit/Software%20Development%20View/dt-kit-software-development-view[Tractus-X Digital Twin KIT] a submodel is accessed via the link:https://internationaldataspaces.org/offers/dataspace-protocol/[Dataspace Protocol (DSP)]:
+
+[source,json,linenums]
+----
+"endpoints": [
+        {
+          "interface": "SUBMODEL-3.0",
+          "protocolInformation": {
+            "href": "https://edc.data.plane/mypath/submodel",
+            "endpointProtocol": "HTTP",
+            "endpointProtocolVersion": [
+              "1.1"
+            ],
+            "subprotocol": "DSP",
+            "subprotocolBody": "id=123;dspEndpoint=http://edc.control.plane/api/v1/dsp",
+            "subprotocolBodyEncoding": "plain",
+            "securityAttributes": [
+              {
+                "type": "NONE",
+                "key": "NONE",
+                "value": "NONE"
+              }
+            ]
 ----
 
 === ProtocolInformation

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -351,7 +351,7 @@ An example ServiceDescription object might look like the following, indicating t
 
 ----
 
-
+[[#query-results]]
 === Query Results
 
 Result elements of AAS queries depend on the declared output selector and the target of the query. Possible targets are Asset Administration Shells, Submodels, Concept Descriptions, Asset Administration Shell Descriptors, and Submodel Descriptors. In accordance, also these objects are returned in the Query Result. In addition, their representation can be controlled via the select statements of the input query, e.g., by only selecting the identifiers of the respective objects rather than the whole content. 
@@ -684,6 +684,7 @@ e|Failed a|The operation failed
 e|Timeout a|The operation has timed out due to given client or server timeout
 |===
 
+
 ===== OperationHandle 
 
 [.table-with-appendix-table]
@@ -698,6 +699,7 @@ h|Attribute h|Explanation h|Type h|Card.
 e|handleId |Handle ID |xref:ShortIdType[ShortIdType] |1
 |===
 
+[[#file-content]]
 === File Content
 
 The “File Content” type of the operations mentioned above is seen as “arbitrary binary data” according to RFC 2046 and is as such defined as byte-array in UTF8-encoding.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -313,7 +313,7 @@ e|https://admin-shell.io/aas/API/3/0/SubmodelRepositoryServiceSpecification/SSP-
 e|https://admin-shell.io/aas/API/3/0/ConceptDescriptionServiceSpecification/SSP-001 |Indicates that the server implemented all details of the Concept Description Service Specification Read Template Profile in version 3.0.
 |===
 
-An example ServiceDescription object might look like the following, indicating that the server supports two profiles at the same time (see Clause 12.12.3 for further details on service specifications and profiles):
+An example ServiceDescription object might look like the following, indicating that the server supports two profiles at the same time (see Clause xref:http-rest-api/service-specifications-and-profile.adoc#submodel-service-specification[] for further details on service specifications and profiles):
 
 [source,json,linenums]
 ----
@@ -323,7 +323,6 @@ An example ServiceDescription object might look like the following, indicating t
     "https://admin-shell.io/aas/API/3/0/RegistryServiceSpecification/SSP-002"
   ]
 }
-
 ----
 
 [[#query-results]]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -150,37 +150,12 @@ See the following example for descriptor endpoints:
     },
 	{
       "protocolInformation": {
-        "endpointAddress": "https://localhost:1234",
+        "endpointAddress": "https://localhost:5678",
         "endpointProtocolVersion": "1.1"
       },
       "interface": "SUBMODEL-2.0"
     }
  ]
-----
-
-In the following example from the link:https://eclipse-tractusx.github.io/docs-kits/kits/Digital%20Twin%20Kit/Software%20Development%20View/dt-kit-software-development-view[Tractus-X Digital Twin KIT] a submodel is accessed via the link:https://internationaldataspaces.org/offers/dataspace-protocol/[Dataspace Protocol (DSP)]:
-
-[source,json,linenums]
-----
-"endpoints": [
-        {
-          "interface": "SUBMODEL-3.0",
-          "protocolInformation": {
-            "href": "https://edc.data.plane/mypath/submodel",
-            "endpointProtocol": "HTTP",
-            "endpointProtocolVersion": [
-              "1.1"
-            ],
-            "subprotocol": "DSP",
-            "subprotocolBody": "id=123;dspEndpoint=http://edc.control.plane/api/v1/dsp",
-            "subprotocolBodyEncoding": "plain",
-            "securityAttributes": [
-              {
-                "type": "NONE",
-                "key": "NONE",
-                "value": "NONE"
-              }
-            ]
 ----
 
 === ProtocolInformation

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -143,14 +143,14 @@ See the following example for descriptor endpoints:
   "endpoints": [
     {
       "protocolInformation": {
-        "endpointAddress": "https://localhost:1234",
+        "endpointAddress": "https://localhost:1234/api/3/submodel",
         "endpointProtocolVersion": "1.1"
       },
       "interface": "SUBMODEL-3.1"
     },
 	{
       "protocolInformation": {
-        "endpointAddress": "https://localhost:5678",
+        "endpointAddress": "https://localhost:5678/api/2/submodel",
         "endpointProtocolVersion": "1.1"
       },
       "interface": "SUBMODEL-2.0"

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -312,8 +312,8 @@ e|profiles |List of implemented server specification profiles. |xref:ServiceSpec
 h|Enumeration e|[[ServiceSpecificationProfileEnum]]ServiceSpecificationProfileEnum
 h|Explanation a|
 The identifiers of the standardized service specification profiles.
-See also clause 12.12 for further details.
-h|semanticId |`\https://admin-shell.io/aas/API/DataTypes/ServiceSpecificationProfileEnum/3/0`
+See also Clause xref:http-rest-api/service-specifications-and-profiles.adoc#[service-specifications-and-profiles] for further details.
+h|semanticId |`\https://admin-shell.io/aas/API/DataTypes/ServiceSpecificationProfileEnum/3/1`
 
 hh|Literal h|Explanation
 e|https://admin-shell.io/aas/API/3/0/AssetAdministrationShellServiceSpecification/SSP-001 |Indicates that the server implemented all features of the Asset Administration Shell Service Specification Full Profile in version 3.0.
@@ -469,10 +469,11 @@ Result elements of AAS queries depend on the declared output selector and the ta
 
 === Simple Data Types
 
-All simple data types from Part 1 xref:bibliography.adoc#bib1[[1\]] apply also to the specifications described in this document.
-Additional data types are defined in Table 2.
+All simple data types from link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#predefined_simple_data_types[Part 1] xref:bibliography.adoc#bib1[[1\]] apply also to the specifications described in this document.
+Additional data types are defined in <<table-simple-data-types-used-for-api-specific-classes>>.
 
 .Simple Data Types used for API-specific Classes
+[[table-simple-data-types-used-for-api-specific-classes]]
 [%autowidth,width="100%",cols="22%,30%,48%",options="header",]
 |===
 |*Primitive* |*Definition* |*Value Examples*
@@ -485,7 +486,7 @@ Additional data types are defined in Table 2.
 
 === Primitive Data Types
 
-All primitive data types from Part 1 apply also to the specifications described in this document.
+All primitive data types from link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#primitive-data-types[Part 1] apply also to the specifications described in this document.
 All constraints and spelling patterns apply as well.
 In addition, the following data types are defined.
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -222,7 +222,7 @@ e|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#Stat
 
 ==== Submodel Interface
 
-[%autowidth,width="100%",cols="42%,58%",options="header",]
+[%autowidth,width="100%",options="header",]
 |===
 2+h|Interface: [[interface-Submodel]]_Submodel_
 h|Operation Name h|Description
@@ -271,7 +271,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetAllSubmodelElements]]GetAllSubmodelElements
 h|Explanation 4+a|Returns all submodel elements including their hierarchy
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelElements/3/0
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelElements/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -290,7 +290,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetSubmodelElementByPath]]GetSubmodelElementByPath
 h|Explanation 4+a|Returns a specific submodel element from the Submodel at a specified path
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelElementByPath/3/0
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelElementByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -308,7 +308,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetFileByPath]]GetFileByPath
 h|Explanation 4+a|Returns a specific file from the Submodel at a specified path
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetFileByPath/3/0
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetFileByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -325,7 +325,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PutFileByPath]]PutFileByPath
 h|Explanation 4+a|Replaces the file of an existing submodel element at a specified path within the submodel element hierarchy
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutFileByPath/3/0
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutFileByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -342,7 +342,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[DeleteFileByPath]]DeleteFileByPath
 h|Explanation 4+a|Deletes the file of an existing submodel element at a specified path within the submodel element hierarchy
-h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteFileByPath/3/0
+h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteFileByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -358,7 +358,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PutSubmodel]]PutSubmodel
 h|Explanation 4+a|Replaces the Submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodel/3/0
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodel/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -375,7 +375,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PatchSubmodel]]PatchSubmodel
 h|Explanation 4+a|Updates the Submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PatchSubmodel/3/0
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PatchSubmodel/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -632,9 +632,9 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 ==== Serialization Interface
 
-[%autowidth,width="100%",cols="27%,73%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
-2+|Interface: [[Serialization]]Serialization
+2+|Interface: [[Serialization]] _Serialization_
 h|Operation Name h|[[Description]]Description
 |xref:GenerateSerializationByIds[GenerateSerializationByIds] |Returns an appropriate serialization based on the specified format (see SerializationFormat).
 |===
@@ -676,9 +676,9 @@ e|application/asset-administration-shell-package+xml a|AASX-Package (binary data
 
 ==== AASX File Server Interface
 
-[%autowidth,width="100%",cols="33%,67%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
-2+|Interface: [[AASX-File-Server]]AASX File Server
+2+|Interface: [[AASX-File-Server]]_AASX File Server_
 h|Operation Name h|Description
 e|xref:GetAllAASXPackageIds[GetAllAASXPackageIds] |Returns a list of available AASX packages at the server
 e|xref:GetAASXByPackageId[GetAASXByPackageId] |Returns a specific AASX package from the server
@@ -815,7 +815,7 @@ These identifiers may be discovered through the interfaces described in <<publis
 
 ==== Asset Administration Shell Registry Interface
 
-[%autowidth,width="100%",cols="45%,55%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
 2+h|Interface: [[interface-AssetAdministrationShellRegistry]]_Asset Administration Shell Registry_
 h|Operation Name h|Description
@@ -990,9 +990,9 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 ==== Submodel Registry Interface
 
-[%autowidth,width="100%",cols="31%,69%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
-2+|Interface: Submodel Registry
+2+|Interface: _Submodel Registry_
 h|Operation Name h|Description
 e|xref:GetAllSubmodelDescriptors[GetAllSubmodelDescriptors] a|Returns all submodel descriptors
 e|xref:GetSubmodelDescriptorById[GetSubmodelDescriptorById] a|Returns a specific submodel descriptor
@@ -1064,7 +1064,7 @@ e|payload a|Created submodel descriptor |yes | xref:specification/interfaces-pay
 |===
 h|Operation Name 4+e|PostBulkSubmodelDescriptors
 h|Explanation    4+a|Creates one or more new submodel descriptors, i.e., registers several submodels
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PostBulkSubmodelDescriptors/3/1
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PostBulkSubmodelDescriptors/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 
@@ -1103,7 +1103,7 @@ e|payload a|Replaced submodel descriptor |yes | xref:specification/interfaces-pa
 |===
 h|Operation Name 4+e|[[PutBulkSubmodelDescriptorsById]]PutBulkSubmodelDescriptorsById
 h|Explanation 4+a|Replaces one or more existing submodel descriptors, i.e., replaces registration information of several submodels
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutBulkSubmodelDescriptorsById/3/1
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutBulkSubmodelDescriptorsById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1137,7 +1137,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[DeleteBulkSubmodelDescriptorsById]]DeleteBulkSubmodelDescriptorsById
 h|Explanation 4+a|Deletes one or more submodel descriptors, i.e., de-registers several submodels
-h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteBulkSubmodelDescriptorsById/3/1
+h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteBulkSubmodelDescriptorsById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1182,7 +1182,7 @@ The interfaces that provide access to the entities (Asset Administration Shells,
 
 ==== Asset Administration Shell Repository Interface
 
-[%autowidth,width="100%",cols="41%,59%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
 2+|Interface: [[interface-AssetAdministrationShellRepository]]_Asset Administration Shell Repository_
 h|Operation Name h|Description
@@ -1372,9 +1372,9 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 ==== Submodel Repository Interface
 
-[%autowidth,width="100%",cols="44%,56%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
-2+|Interface: [[interface-SubmodelRepository]]Submodel Repository
+2+|Interface: [[interface-SubmodelRepository]]_Submodel Repository_
 h|Operation Name h|Description
 e|xref:GetAllSubmodels[GetAllSubmodels] |Returns all Submodels
 e|xref:GetSubmodelById[GetSubmodelById]|Returns a specific Submodel
@@ -1586,9 +1586,9 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 ==== Concept Description Repository Interface
 
-[%autowidth,width="100%",cols="55%,45%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
-2+|Interface: Concept Description Repository
+2+|Interface: _Concept Description Repository_
 h|Operation Name h|Description
 e|xref:GetAllConceptDescriptions[GetAllConceptDescriptions] |Returns all Concept Descriptions
 e|xref:GetConceptDescriptionById[GetConceptDescriptionById] |Returns a specific Concept Description
@@ -1795,9 +1795,9 @@ These interfaces allow to publish information about Asset Administration Shells 
 
 ==== Asset Administration Shell Basic Discovery Interface
 
-[%autowidth,width="100%",cols="45%,55%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
-2+|Interface: Asset Administration Shell Basic Discovery
+2+|Interface: _Asset Administration Shell Basic Discovery_
 h|Operation Name h|Description
 e| xref:GetAllAssetAdministrationShellIdsByAssetLink[GetAllAssetAdministrationShellIdsByAssetLink] |Returns a list of Asset Administration Shell ids based on asset identifier key-value-pairs
 e| xref:GetAllAssetLinksById[GetAllAssetLinksById]  |Returns a list of asset identifier key-value-pairs based on a given Asset Administration Shell id
@@ -1912,9 +1912,9 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 === Self-Description Interface
 
-[%autowidth,width="100%",cols="19%,81%",options="header",]
+[%autowidth,width="100%",options="header"]
 |===
-2+|Interface: Self-Description
+2+|Interface: _Self-Description_
 h|Operation Name h|Description
 e|xref:GetSelfDescription[GetSelfDescription] |Returns a description object containing the capabilities and supported features of the server.
 |===

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -184,7 +184,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
 5+h|Output Parameter
 e|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-e|payload a|Requested thumbnail file |yes |File Content |1
+e|payload a|Requested thumbnail file |yes | xref:specification/interfaces-payload.adoc#file-content[File Content] |1
 |===
 
 ==== Operation PutThumbnail
@@ -198,7 +198,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PutThumbnail/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-e|file a|Thumbnail file |yes |File Content |1
+e|file a|Thumbnail file |yes |xref:specification/interfaces-payload.adoc#file-content[File Content] |1
 5+h|Output Parameter
 e|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -294,7 +294,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelElementByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path | {path} |yes |Key |1..*
+|path | {path} |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 |serializationModifier |Defines the format of the response |no |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
@@ -312,10 +312,10 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetFileByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path} |yes |Key |1..*
+|path |{path} |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested file |yes |File Content |0..1
+|payload |Requested file |yes |xref:specification/interfaces-payload.adoc#file-content[File Content] |0..1
 |===
 
 ==== Operation PutFileByPath
@@ -329,8 +329,8 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PutFileByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path} |yes |Key |1..*
-|payload |Replacing file |yes |File Content |1
+|path |{path} |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
+|payload |Replacing file |yes |xref:specification/interfaces-payload.adoc#file-content[File Content] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -346,7 +346,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteFileByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |idShortPath via relative Reference/Keys to a submodel element |yes |Key |1..*
+|path |idShortPath via relative Reference/Keys to a submodel element |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key]  |1..*
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -362,10 +362,10 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodel/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|submodel |Submodel object |yes |Submodel |1
+|submodel |Submodel object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel]  |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Replaced submodel |yes |Submodel |1
+|payload |Replaced submodel |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 |===
 
 ==== Operation PatchSubmodel
@@ -389,10 +389,10 @@ Note: values remain unchanged with content=metadata.
 
 
 |no |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
-|submodel |Submodel object |yes |Submodel |1
+|submodel |Submodel object |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Updated submodel |yes |Submodel |1
+|payload |Updated submodel |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 |===
 
 ==== Operation PostSubmodelElement
@@ -417,7 +417,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 5+h|Input Parameter
 
-|submodelElement |Submodel element object |yes |SubmodelElement |
+|submodelElement |Submodel element object |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SubmodelElement[SubmodelElement] |
 
 5+h|Output Parameter
 
@@ -445,7 +445,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PostSubmodelElementByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path} under which the new SubmodelElement shall be added |yes |Key |1..*
+|path |{path} under which the new SubmodelElement shall be added |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 |submodelElement |Submodel element object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SubmodelElement[SubmodelElement] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
@@ -467,7 +467,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodelElementByPath/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path} which shall be replaced |yes |Key |1..*
+|path |{path} which shall be replaced |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 |submodelElement |Submodel element object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SubmodelElement[SubmodelElement] |1
 5+h|Output Parameter
 |StatusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
@@ -496,7 +496,7 @@ Note: values remain unchanged with content=metadata.
 
 |no |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier] |1
 
-|path |{path} |yes |Key |1..*
+|path |{path} |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 |submodelElement |Submodel element object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SubmodelElement[SubmodelElement] |1
 
 5+h|Output Parameter
@@ -533,7 +533,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PatchSubmodelElementValueByPath
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path} |yes |Key |1..*
+|path |{path} |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 |payload |The new value of the submodel element |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SubmodelElement[SubmodelElement] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
@@ -550,7 +550,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteSubmodelElementByPath/3/0
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path} |yes |Key |1..*
+|path |{path} |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -566,7 +566,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/InvokeOperationSync/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path}, in this case an operation |yes |Key |1..*
+|path |{path}, in this case an operation |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 |inputArgument |Input argument |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/submodel-elements.html#OperationVariable[OperationVariable] |1..*
 |inoutputArgument |Inoutput argument |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/submodel-elements.html#OperationVariable[OperationVariable] |1..*
 5+h|Output Parameter
@@ -585,13 +585,13 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/InvokeOperationAsync/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path}, in this case an operation |yes |Key |1..*
+|path |{path}, in this case an operation |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 |inputArgument |Input argument |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/submodel-elements.html#OperationVariable[OperationVariable] |1..*
 |inoutputArgument |Inoutput argument |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/submodel-elements.html#OperationVariable[OperationVariable] |1..*
 |clientTimeoutDuration |Timestamp indicating when the client expects the server to have finished execution of the invoked operation |yes |duration |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes |OperationHandle |1
+|payload |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes | xref:specification/interfaces-payload.adoc#OperationHandle[OperationHandle] |1
 |===
 
 ==== Operation GetOperationAsyncStatus
@@ -605,7 +605,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetOperationAsnycStatus/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|operationHandle |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes |xref:OperationHandle[OperationHandle] |1
+|operationHandle |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes | xref:specification/interfaces-payload.adoc#OperationHandle[OperationHandle] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |Execution state of the operation |yes | xref:BaseOperationResult[BaseOperationResult] |1
@@ -622,7 +622,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetOperationAsnycResult/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|operationHandle |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes |OperationHandle |1
+|operationHandle |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes |xref:specification/interfaces-payload.adoc#OperationHandle[OperationHandle] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |Operation Result |yes |xref:OperationResult[OperationResult] |1
@@ -636,7 +636,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 2+|Interface: [[Serialization]] _Serialization_
 h|Operation Name h|[[Description]]Description
-|xref:GenerateSerializationByIds[GenerateSerializationByIds] |Returns an appropriate serialization based on the specified format (see SerializationFormat).
+|xref:GenerateSerializationByIds[GenerateSerializationByIds] |Returns an appropriate serialization based on the specified format (see xref:specification/interfaces.adoc#SerializationFormat[SerializationFormat]).
 |===
 
 ==== Operation GenerateSerializationByIds
@@ -645,15 +645,15 @@ h|Operation Name h|[[Description]]Description
 [width=100%,cols="25%,35%,10%,20%,10%"]
 |===
 h|Operation Name 4+e|[[GenerateSerializationByIds]]GenerateSerializationByIds
-h|Explanation 4+a|Returns an appropriate serialization based on the specified format (see SerializationFormat).
+h|Explanation 4+a|Returns an appropriate serialization based on the specified format (see xref:specification/interfaces.adoc#SerializationFormat[SerializationFormat]).
 h|semanticId 4+|`\https://admin-shell.io/aas/API/GenerateSerializationByIds/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|aasIds |The unique ids of the Asset Administration Shells to be contained in the serialization |no |Identifier |1..*
-|submodelIds |The unique ids of the Submodels to be contained in the serialization |no |Identifier |1..*
+|aasIds |The unique ids of the Asset Administration Shells to be contained in the serialization |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1..*
+|submodelIds |The unique ids of the Submodels to be contained in the serialization |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1..*
 |includeConceptDescriptions |Include concept descriptions |no |boolean |1
-|serializationFormat |Denotes in which serialization format the requested content shall be delivered |no |SerializationFormat |1
+|serializationFormat |Denotes in which serialization format the requested content shall be delivered |no |xref:specification/interfaces.adoc#SerializationFormat[SerializationFormat] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |Serialization of the requested Asset Administration Shells and/or Submodels with or without ConceptDescriptions in specified SerializationFormat. |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/environment.html#Environment[Environment] |1
@@ -698,12 +698,12 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAASXPackageIds/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|aasId |Identifier of the AAS which must exist in each matching AASX package |no |Identifier |1
+|aasId |Identifier of the AAS which must exist in each matching AASX package |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Matching package list; the PackageDescription includes all Asset Administration Shell identifiers, also those which may have not been requested through the aasId input parameter |yes |PackageDescription |0..*
+|payload |Matching package list; the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/http-rest-api.html#PackageDescription[PackageDescription] includes all Asset Administration Shell identifiers, also those which may have not been requested through the aasId input parameter |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/http-rest-api.html#PackageDescription[PackageDescription] |0..*
 |===
 
 ==== Operation GetAASXByPackageId
@@ -721,7 +721,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |filename |Filename of the AASX package |yes |string |1
-|payload |Requested AASX package |yes |AASX Package |1
+|payload |Requested AASX package |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01005/v3.1/index.html[AASX package] |1
 |===
 
 ==== Operation PostAASXPackage
@@ -745,8 +745,8 @@ Servers may simply store the AASX files with their related given aasIds.
 ====
 
 
-|no |Identifier |0..*
-|file |New AASX package |yes |AASX package |1
+|no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |0..*
+|file |New AASX package |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01005/v3.1/index.html[AASX package] |1
 |filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
@@ -775,8 +775,8 @@ Servers may simply store the AASX files with their related given aasIds.
 ====
 
 
-|no |Identifier |0..*
-|file |New AASX package |yes |AASX package |1
+|no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |0..*
+|file |New AASX package |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01005/v3.1/index.html[AASX package] |1
 |filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
@@ -844,8 +844,8 @@ h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
-|assetKind |The kind of the assets to retrieve (Type, Instance etc.) | no |AssetKind |1
-|assetType |The type of the assets to retrieve, encoded as unique ID | no |Identifier |1
+|assetKind |The kind of the assets to retrieve (Type, Instance etc.) | no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetKind[AssetKind] |1
+|assetType |The type of the assets to retrieve, encoded as unique ID | no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |List of Asset Administration Shell Descriptors |no | xref:specification/interfaces-payload.adoc#AssetAdministrationShellDescriptor[AssetAdministrationShellDescriptor]  |1..*
@@ -862,7 +862,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAssetAdministrationShellDesc
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|aasIdentifier |The Asset Administration Shell’s unique ID |yes |Identifier |1
+|aasIdentifier |The Asset Administration Shell’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode]|1
 |payload |Requested Asset Administration Shell Descriptor |yes | xref:specification/interfaces-payload.adoc#AssetAdministrationShellDescriptor[AssetAdministrationShellDescriptor]  |1
@@ -946,7 +946,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteAssetAdministrationShellD
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|aasIdentifier |The Asset Administration Shell’s unique ID |yes |Identifier |1
+|aasIdentifier |The Asset Administration Shell’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -1034,7 +1034,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelDescriptorById/3/0`
 =
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-e|submodelIdentifier a|The Submodel’s unique ID |yes |Identifier |1
+e|submodelIdentifier a|The Submodel’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 e|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 e|payload a|Requested submodel descriptor |yes |SubmodelDescriptor |1
@@ -1125,7 +1125,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteSubmodelDescriptorById/3/
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|submodelIdentifier |The Submodel’s unique id |yes |Identifier |1
+|submodelIdentifier |The Submodel’s unique id |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -1141,7 +1141,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteBulkSubmodelDescriptorsBy
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|submodelIdentifier |The Submodel’s unique ID |yes |Identifier |1..*
+|submodelIdentifier |The Submodel’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1..*
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -1157,7 +1157,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/QuerySubmodelDescriptors/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|query | Query conforming to the AAS Query Language |yes | AAS Query |1
+|query | Query conforming to the AAS Query Language |yes | xref:general.adoc#query-grammar[AAS Query] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |List of Submodel Descriptors or Submodel identifiers |no | xref:specification/interfaces-payload.adoc#QueryResult[QueryResult<SubmodelDescriptor>]  |1..*
@@ -1235,7 +1235,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAssetAdministrationShellById
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|id |The Asset Administration Shell’s unique ID |yes |Identifier |1
+|id |The Asset Administration Shell’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 |serializationModifier |Defines the format of the response |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
@@ -1344,7 +1344,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteAssetAdministrationShellB
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|id |The Asset Administration Shell’s unique ID |yes |Identifier |1
+|id |The Asset Administration Shell’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -1361,7 +1361,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/QueryAssetAdministrationShells/
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|query | Query conforming to the AAS Query Language |yes | AAS Query |1
+|query | Query conforming to the AAS Query Language |yes | xref:general.adoc#query-grammar[AAS Query] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |List of Asset Administration Shells or AAS identifiers |no | xref:specification/interfaces-payload.adoc#QueryResult[QueryResult<AssetAdministrationShell>]  |1..*
@@ -1413,7 +1413,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |List of Submodels |no |Submodel |1..*
+|payload |List of Submodels |no | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1..*
 |===
 
 ==== Operation GetSubmodelById
@@ -1427,11 +1427,11 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelById/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|id |The Submodel’s unique ID |yes |Identifier |1
+|id |The Submodel’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 |serializationModifier |Defines the format of the response |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Submodel |yes |Submodel |1
+|payload |Requested Submodel |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 |===
 
 ==== Operation GetAllSubmodelsBySemanticId
@@ -1453,7 +1453,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Submodels |no |Submodel |1..*
+|payload |Requested Submodels |no | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1..*
 |===
 
 ==== Operation GetAllSubmodelsByIdShort
@@ -1473,7 +1473,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Submodels |no |Submodel |1..*
+|payload |Requested Submodels |no | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1..*
 |===
 
 ==== Operation PostSubmodel
@@ -1496,10 +1496,10 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PostSubmodel/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|submodel |Submodel object |yes |Submodel |1
+|submodel |Submodel object |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Created Submodel |yes |Submodel |1
+|payload |Created Submodel |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 |===
 
 ==== Operation PutSubmodelById
@@ -1513,10 +1513,10 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodelById/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|submodel |Submodel object |yes |Submodel |1
+|submodel |Submodel object |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Replaced Submodel |yes |Submodel |1
+|payload |Replaced Submodel |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 |===
 
 ==== Operation PatchSubmodelById
@@ -1540,10 +1540,10 @@ Note: values remain unchanged with content=metadata.
 
 
 |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier] |1
-|submodel |Submodel object |yes |Submodel |1
+|submodel |Submodel object |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Updated submodel |yes |Submodel |1
+|payload |Updated submodel |yes | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#Submodel[Submodel] |1
 |===
 
 ==== Operation DeleteSubmodelById
@@ -1557,7 +1557,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteSubmodelById/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-e|id a|The Submodel’s unique ID |yes |Identifier |1
+e|id a|The Submodel’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 e|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -1575,7 +1575,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/QuerySubmodels/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|query | Query conforming to the AAS Query Language |yes | AAS Query |1
+|query | Query conforming to the AAS Query Language |yes | xref:general.adoc#query-grammar[AAS Query] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |List of Submodels or Submodel identifiers |no | xref:specification/interfaces-payload.adoc#Submodel[Submodel]  |1..*
@@ -1639,7 +1639,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetConceptDescriptionById/3/0`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|id |The Concept Description’s unique ID |yes |Identifier |1
+|id |The Concept Description’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |Requested Concept Description |yes |ConceptDescription |1
@@ -1760,7 +1760,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteConceptDescriptionById/3/
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|cdIdentifier |The Concept Description’s unique id |yes |Identifier |1
+|cdIdentifier |The Concept Description’s unique id |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -1776,7 +1776,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/QueryConceptDescriptions/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|query | The specific query conformant to the AAS Query Language, containing filter conditions for the required Concept Descriptions. | yes | Query |1
+|query | The specific query conformant to the AAS Query Language, containing filter conditions for the required Concept Descriptions. | yes | xref:general.adoc#query-grammar[AAS Query] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload | List of requested Concept Descriptions or identifiers |no | xref:specification/interfaces-payload.adoc#QueryResult[QueryResult<ConceptDescription>] |1..*
@@ -1831,7 +1831,7 @@ It is the predefined key “_globalAssetId_” that would refer to the _AssetInf
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Identifiers of all Asset Administration Shells which contain all asset identifier key-value-pairs in their asset information, i.e. AND-match of key-value-pairs per Asset Administration Shell |no |Identifier |1..*
+|payload |Identifiers of all Asset Administration Shells which contain all asset identifier key-value-pairs in their asset information, i.e. AND-match of key-value-pairs per Asset Administration Shell |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1..*
 |===
 
 ==== Operation GetAllAssetLinksById


### PR DESCRIPTION
- [major change: examples for endpoints in Descriptors changed](https://github.com/admin-shell-io/aas-specs-api/pull/367/commits/d0132173181e705f588e6339bafc6fa869ea5a80)
- [major change: add conformance and versioning subchapters in index.adoc](https://github.com/admin-shell-io/aas-specs-api/pull/367/commits/ce513b173225dc642c131fbe52f44756002dcfd1)
- correct semanticId of ServiceSpecificationProfileEnum: is /3/1
- editorial changes like
   - adding links to Part 1 and within Part 2
   - formatting 