### PR TITLE
Correct IDs of operations and or payload classes + formatting/editorial changes

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -15,7 +15,7 @@ Major Changes:
 
 
 * Bulk Operations and Profiles for Bulk Operations (https://github.com/admin-shell-io/aas-specs-api/issues/3[#3])
-* new Query Interface and API Operations
+* new Query API-Operations
 * deprecated: operation GetAllAssetAdministrationShellIdsByAssetLink 
 * new: operation  SearchAllAssetAdministrationShellIdsByAssetLink  (as substitute for GetAllAssetAdministrationShellIdsByAssetLink) (https://github.com/admin-shell-io/aas-specs-api/issues/19[#19])
 * new Profile for Discovery Service: Read Only SSP-002 (https://github.com/admin-shell-io/aas-specs-api/issues/201[#201])
@@ -23,6 +23,7 @@ Major Changes:
 	** changed: interface
 	** changed: service
 * Individual versioning of datatype IDs, operations, interfaces etc. (https://github.com/admin-shell-io/aas-specs-api/issues/247[#247])
+	** including changes due to implicit changes of IDTA-01001, e.g. of primitive data types NameType and Identifier 
 * Data type  Identifier: change length from 2000 to 2048 characters (https://github.com/admin-shell-io/aas-specs/issues/306[#306])
 * Transfer of chapters on formats Metadata, Paths and Value-Only from Part 2 API to Part 1 Metamodel (https://github.com/admin-shell-io/aas-specs-api/issues/214[#214])
 * Transfer from .docx to asciidoc (.adoc) and maintenance in GitHub

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -15,7 +15,7 @@ Major Changes:
 
 
 * Bulk Operations and Profiles for Bulk Operations (https://github.com/admin-shell-io/aas-specs-api/issues/3[#3])
-* new Query API-Operations
+* new Query Operations and Profiles for executing complex queries
 * deprecated: operation GetAllAssetAdministrationShellIdsByAssetLink 
 * new: operation  SearchAllAssetAdministrationShellIdsByAssetLink  (as substitute for GetAllAssetAdministrationShellIdsByAssetLink) (https://github.com/admin-shell-io/aas-specs-api/issues/19[#19])
 * new Profile for Discovery Service: Read Only SSP-002 (https://github.com/admin-shell-io/aas-specs-api/issues/201[#201])

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -126,7 +126,7 @@ _Serialization API:_[.underline]# +
 _Description API:_ +
 xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
-|xref:specification/interfaces-operation-parameters.html#SerializationModifier[SerializationModifier] a|
+|xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier] a|
 Level: Core, Deep
 
 Content: Normal, Metadata, Value, Reference, Path
@@ -443,12 +443,12 @@ h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/AssetAdministrationS
 h|Feature h|Appearance
 |APIs and API Operations a|
 _AAS Registry API:_ +
-QueryAssetAdministrationShellDescriptors 
-QueryAssetAdministrationShellDescriptorIds 
+xref:specification/interfaces.adoc#QueryAssetAdministrationShellDescriptors[QueryAssetAdministrationShellDescriptors] +
+xref:specification/interfaces.adoc#QueryAssetAdministrationShellDescriptorIds[QueryAssetAdministrationShellDescriptorIds]
 
 
 _Description API:_ +
-GetDescription
+xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 |SerializationModifier |not applicable
 |SerializationFormat |JSON
@@ -524,10 +524,9 @@ h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/SubmodelRegistryServ
 h|Feature h|Appearance
 |APIs and API Operations a|
 __Submodel Registry API:__ +
-PostBulkSubmodelDescriptors +
-PutBulkSubmodelDescriptorsById +
-DeleteBulkSubmodelDescriptorsById
-
+xref:specification/interfaces.adoc#PostBulkSubmodelDescriptors[PostBulkSubmodelDescriptors ] +
+xref:specification/interfaces.adoc#PutBulkSubmodelDescriptorsById[PutBulkSubmodelDescriptorsById] +
+xref:specification/interfaces.adoc#DeleteBulkSubmodelDescriptorsById[DeleteBulkSubmodelDescriptorsById]
 
 __Description API:__ +
 xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
@@ -547,13 +546,13 @@ h|Name: h|Submodel Registry Bulk Profile
 h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/1/SubmodelRegistryServiceSpecification/SSP-004`
 h|Feature h|Appearance
 |APIs and API Operations a|
-__Submodel Registry API: +
-QuerySubmodelDescriptors +
-QuerySubmodelDescriptorIds
+__Submodel Registry API:__ +
+xref:specification/interfaces.adoc#QuerySubmodelDescriptors[QuerySubmodelDescriptors] +
+xref:specification/interfaces.adoc#QuerySubmodelDescriptorIds[QuerySubmodelDescriptorIds]
 
 
-__Description API: +
-__GetDescription
+__Description API:__ +
+xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 |SerializationModifier |not applicable
 |SerializationFormat |JSON
@@ -772,7 +771,7 @@ QueryAssetAdministrationShells +
 QueryAssetAdministrationShellIds
 
 _Description API:_ +
-GetDescription
+xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 |SerializationModifier a| not applicable 
 |SerializationFormat |JSON
@@ -783,7 +782,7 @@ See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRepos
 
 == Submodel Repository Service Specification
 
-[%autowidth,width="100%",cols="41%,59%",options="header",]
+[cols="41%,59%"]
 |===
 h|Service Specification / Profiles h|Description
 |SubmodelRepositoryServiceSpecification/SSP-001 |Full feature set
@@ -1016,7 +1015,7 @@ QuerySubmodels +
 QuerySubmodelIds
 
 _Description API:_ +
-GetDescription
+xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 |SerializationModifier a| not applicable 
 |SerializationFormat |JSON
@@ -1027,7 +1026,7 @@ See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpec
 
 == Concept Description Repository Service Specification
 
-[%autowidth,width="100%",cols="59%,41%",options="header",]
+[cols="59%,41%"]
 |===
 h|Service Specification / Profiles h|Description
 |ConceptDescriptionRepositoryServiceSpecification/SSP-001 |Full feature set
@@ -1078,7 +1077,7 @@ QueryConceptDescriptions +
 QueryConceptDescriptionIds
 
 _Description API:_ +
-GetDescription
+xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 |SerializationModifier |not applicable
 |SerializationFormat |JSON

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -331,7 +331,7 @@ An example ServiceDescription object might look like the following, indicating t
 Result elements of AAS queries depend on the declared output selector and the target of the query. Possible targets are Asset Administration Shells, Submodels, Concept Descriptions, Asset Administration Shell Descriptors, and Submodel Descriptors. In accordance, also these objects are returned in the Query Result. In addition, their representation can be controlled via the select statements of the input query, e.g., by only selecting the identifiers of the respective objects rather than the whole content. 
 
 .Simple Data Types used for API-specific Classes
-[%autowidth, width="100%", cols="20%,20%,60%",options="header",]
+[cols="26%,24%,50%"]
 |===
 h|Query Result h|Definition h|Value Examples
 e|QueryResult<AssetAdministrationShell> |List of Asset Administration Shells _or_ a list of Asset Administration Shell identifiers a|
@@ -359,8 +359,9 @@ e|QueryResult<AssetAdministrationShell> |List of Asset Administration Shells _or
 [ 
    "https://example.com/aas-1", 
    "https://example.com/aas-2", 
-   ... +
-] +
+   ... 
+] 
+----
 |QueryResult<Submodel> |List of Submodels _or_ a list of Submodel identifiers a|
 
 [source,json,linenums]
@@ -369,9 +370,9 @@ e|QueryResult<AssetAdministrationShell> |List of Asset Administration Shells _or
    { 
       "modelType": "Submodel", 
       "id": "https://example.com/sm-1", 
-      ... +
-   }, +
-   { +
+      ... 
+   }, 
+   { 
       "modelType": "Submodel", 
       "id": "https://example.com/sm-2", 
       ... 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -37,7 +37,7 @@ h|Explanation 3+a|
 The self-describing information of a network resource.
 This class is not part of the metamodel.
 h|Inherits from 3+|--
-h|semanticId 3+|`\https://admin-shell.io/aas/API/DataTypes/Descriptor/3/0`
+h|semanticId 3+|`\https://admin-shell.io/aas/API/DataTypes/Descriptor/3/1`
 h|Attribute h|Explanation h|Type h|Card.
 e|description a|
 Description or comments on the element
@@ -108,7 +108,7 @@ h|Explanation 3+a|
 The endpoint description of a network resource.
 This class is not part of the metamodel.
 h|Inherits from 3+|-
-h|semanticId 3+|`\https://admin-shell.io/aas/API/DataTypes/Endpoint/3/0`
+h|semanticId 3+|`\https://admin-shell.io/aas/API/DataTypes/Endpoint/3/1`
 
 h|Attribute h|Explanation h|Type h|Card.
 e|protocolInformation a|Protocol information of the network resource endpoint |xref:ProtocolInformation[ProtocolInformation] |1
@@ -275,7 +275,7 @@ This class is not part of the metamodel.
 
 
 h|Inherits from 3+|--
-h|semanticId 3+| `\https://admin-shell.io/aas/API/DataTypes/ServiceDescription/3/0`
+h|semanticId 3+| `\https://admin-shell.io/aas/API/DataTypes/ServiceDescription/3/1`
 
 h|Attribute h|Explanation h|Type h|Card.
 e|profiles |List of implemented server specification profiles. |xref:ServiceSpecificationProfileEnum[ServiceSpecificationProfileEnum] |1..*
@@ -477,7 +477,7 @@ Additional data types are defined in <<table-simple-data-types-used-for-api-spec
 
 .Simple Data Types used for API-specific Classes
 [[table-simple-data-types-used-for-api-specific-classes]]
-[%autowidth,width="100%",cols="22%,30%,48%",options="header",]
+[cols="22%,30%,48%"]
 |===
 |*Primitive* |*Definition* |*Value Examples*
 |NonNegativeInteger |The _nonNegativeInteger_ datatype as defined by XML Schema Part 2 in version 1.0 footnote:[https://www.w3.org/TR/xmlschema-2/] a|
@@ -494,7 +494,7 @@ All constraints and spelling patterns apply as well.
 In addition, the following data types are defined.
 
 .Primitive Data Types used for the API-specific Classes
-[%autowidth,width="100%",cols="14%,44%,42%",options="header",]
+[cols="14%,44%,42%"]
 |===
 |*Primitive* |*Definition* |*Value Examples*
 |[[CodeType]]CodeType |_string_ with max 32 and min 1 characters a|
@@ -648,7 +648,7 @@ h|Attribute h|Explanation h|Type h|Card.
 h|Class Name 3+e|[[BaseOperationResult]]BaseOperationResult
 h|Explanation 3+a|The object containing the intermediate state of an operation
 h|Inherits from 3+|Result
-h|semanticId 3+|`\https://admin-shell.io/aas/API/DataTypes/BaseOperationResult/3/0`
+h|semanticId 3+|`\https://admin-shell.io/aas/API/DataTypes/BaseOperationResult/3/1`
 
 h|Attribute h|Explanation h|Type h|Card.
 e|executionState |Execution state |xref:ExecutionState[ExecutionState] |1

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -44,7 +44,7 @@ Description or comments on the element
 
 The description can be provided in several languages
 
-|link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#MultiLanguageNameType[MultiLanguageNameType] |0..1
+|link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#MultiLanguageTextType[MultiLanguageTextType] |0..1
 
 e|displayName a|Display name; can be provided in several languages | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#MultiLanguageNameType[MultiLanguageNameType] |0..1
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -44,9 +44,9 @@ Description or comments on the element
 
 The description can be provided in several languages
 
-|link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#MultiLanguageTextType[MultiLanguageNameType] |0..1
+|link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#MultiLanguageNameType[MultiLanguageNameType] |0..1
 
-e|displayName a|Display name; can be provided in several languages | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#MultiLanguageTextType[MultiLanguageNameType] |0..1
+e|displayName a|Display name; can be provided in several languages | link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#MultiLanguageNameType[MultiLanguageNameType] |0..1
 
 e|extension a|An extension of the element |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#Extension[Extension] |0..*
 |===
@@ -290,7 +290,7 @@ The identifiers of the standardized service specification profiles.
 See also Clause xref:http-rest-api/service-specifications-and-profiles.adoc#[service-specifications-and-profiles] for further details.
 h|semanticId |`\https://admin-shell.io/aas/API/DataTypes/ServiceSpecificationProfileEnum/3/1`
 
-hh|Literal h|Explanation
+h|Literal h|Explanation
 e|https://admin-shell.io/aas/API/3/0/AssetAdministrationShellServiceSpecification/SSP-001 |Indicates that the server implemented all features of the Asset Administration Shell Service Specification Full Profile in version 3.0.
 e|https://admin-shell.io/aas/API/3/0/AssetAdministrationShellServiceSpecification/SSP-002 |Indicates that the server implemented all features of the Asset Administration Shell Service Specification Read Profile in version 3.0.
 e|https://admin-shell.io/aas/API/3/0/SubmodelServiceSpecification/SSP-001 |Indicates that the server implemented all features of the Submodel Service Specification Full Profile in version 3.0.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -562,7 +562,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[InvokeOperationSync]]InvokeOperationSync
 h|Explanation 4+a|Synchronously invokes an Operation at a specified path
-h|semanticId 4+|`\https://admin-shell.io/aas/API/InvokeOperationSync/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/InvokeOperationSync/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -601,7 +601,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetOperationAsyncStatus]]GetOperationAsyncStatus
 h|Explanation 4+a|Returns the current status of an asynchronously invoked operation
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetOperationAsnycStatus/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetOperationAsnycStatus/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -618,7 +618,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetOperationAsyncResult]]GetOperationAsyncResult
 h|Explanation 4+a|Returns the OperationResult of an asynchronously invoked operation
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetOperationAsnycResult/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetOperationAsnycResult/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -858,7 +858,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetAssetAdministrationShellDescriptorById]]GetAssetAdministrationShellDescriptorById
 h|Explanation 4+a|Returns a specific Asset Administration Shell Descriptor
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAssetAdministrationShellDescriptorById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAssetAdministrationShellDescriptorById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -875,7 +875,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PostAssetAdministrationShellDescriptor]]PostAssetAdministrationShellDescriptor
 h|Explanation 4+a|Creates a new Asset Administration Shell Descriptor, i.e., registers an AAS
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAssetAdministrationShellDescriptor/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAssetAdministrationShellDescriptor/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -908,7 +908,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PutAssetAdministrationShellDescriptorById]]PutAssetAdministrationShellDescriptorById
 h|Explanation 4+a|Replaces an existing Asset Administration Shell Descriptor, i.e., replaces registration information
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutAssetAdministrationShellDescriptorById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutAssetAdministrationShellDescriptorById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1012,7 +1012,7 @@ e|xref:QuerySubmodelDescriptors[QuerySubmodelDescriptors] a| Returns all Submode
 |===
 h|Operation Name 4+e|[[GetAllSubmodelDescriptors]]GetAllSubmodelDescriptors
 h|Explanation 4+a|Returns all submodel descriptors
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelDescriptors/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelDescriptors/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1030,7 +1030,7 @@ e|payload a|List of requested submodel descriptors |no |SubmodelDescriptor |1..*
 |===
 h|Operation Name 4+e|[[GetSubmodelDescriptorById]]GetSubmodelDescriptorById
 h|Explanation 4+a|Returns a specific Submodel Descriptor
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelDescriptorById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelDescriptorById/3/1`
 =
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1047,7 +1047,7 @@ e|payload a|Requested submodel descriptor |yes |SubmodelDescriptor |1
 |===
 h|Operation Name 4+e|[[PostSubmodelDescriptor]]PostSubmodelDescriptor
 h|Explanation 4+a|Creates a new submodel descriptor, i.e. registers a submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PostSubmodelDescriptor/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PostSubmodelDescriptor/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1085,7 +1085,7 @@ Descriptor    a|Object containing the Submodel’s identification and endpoint i
 |===
 h|Operation Name 4+e|[[PutSubmodelDescriptorById]]PutSubmodelDescriptorById
 h|Explanation 4+a|Replaces an existing submodel descriptor, i.e., replaces registration information
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodelDescriptorById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodelDescriptorById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1121,7 +1121,7 @@ Descriptor |Object containing the Submodel’s identification and endpoint infor
 |===
 h|Operation Name 4+e|[[DeleteSubmodelDescriptorById]]DeleteSubmodelDescriptorById
 h|Explanation 4+a|Deletes a Submodel Descriptor, i.e., de-registers a submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteSubmodelDescriptorById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteSubmodelDescriptorById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1212,7 +1212,7 @@ e|xref:QueryAssetAdministrationShells[QueryAssetAdministrationShells] a| Returns
 |===
 h|Operation Name 4+e|[[GetAllAssetAdministrationShells]]GetAllAssetAdministrationShells
 h|Explanation 4+a|Returns all Asset Administration Shells
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShells/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShells/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1231,7 +1231,7 @@ e|payload a|List of Asset Administration Shells |no |AssetAdministrationShell |1
 |===
 h|Operation Name 4+e|[[GetAssetAdministrationShellById]]GetAssetAdministrationShellById
 h|Explanation 4+a|Returns a specific Asset Administration Shell
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAssetAdministrationShellById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAssetAdministrationShellById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1251,7 +1251,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetAllAssetAdministrationShellsByAssetId]]GetAllAssetAdministrationShellsByAssetId
 h|Explanation 4+a|Returns all Asset Administration Shells that are linked to a globally unique asset identifier or to specific asset ids
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShellsByAssetId/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShellsByAssetId/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1272,7 +1272,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetAllAssetAdministrationShellsByIdShort]]GetAllAssetAdministrationShellsByIdShort
 h|Explanation 4+a|Returns all Asset Administration Shells with a specific _idShort_
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShellsByIdShort/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShellsByIdShort/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1301,7 +1301,7 @@ Note: the creation of the idShort is out of scope and must be handled in a propr
 ====
 
 
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAssetAdministrationShell/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAssetAdministrationShell/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 
@@ -1323,7 +1323,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PutAssetAdministrationShellById]]PutAssetAdministrationShellById
 h|Explanation 4+a|Replaces an existing Asset Administration Shell
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutAssetAdministrationShellById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutAssetAdministrationShellById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1340,7 +1340,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[DeleteAssetAdministrationShellById]]DeleteAssetAdministrationShellById
 h|Explanation 4+a|Deletes an Asset Administration Shell
-h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteAssetAdministrationShellById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteAssetAdministrationShellById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1404,7 +1404,7 @@ e|xref:QuerySubmodels[QuerySubmodels] a| Returns all Submodels that conform to a
 |===
 h|Operation Name 4+e|[[GetAllSubmodels]]GetAllSubmodels
 h|Explanation 4+a|Returns all Submodels
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodels/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodels/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1423,7 +1423,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetSubmodelById]]GetSubmodelById
 h|Explanation 4+a|Returns a specific Submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1443,7 +1443,7 @@ h|Operation Name 4+e|[[GetAllSubmodelsBySemanticId]]GetAllSubmodelsBySemanticId
 h|Explanation 4+a|
 Returns all Submodels with a specific SemanticId or SupplementalSemanticId.
 If either the semanticId fits to the input parameter or at least one of the SupplementalSemanticIds, the submodel is returned.
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelsBySemanticId/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelsBySemanticId/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1463,7 +1463,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|((GetAllSubmodelsByIdShort))GetAllSubmodelsByIdShort
 h|Explanation 4+a|Returns all Submodels with a specific _idShort_
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelsByIdShort/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelsByIdShort/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1492,7 +1492,7 @@ Note: the creation of the idShort is out of scope and must be handled in a propr
 ====
 
 
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PostSubmodel/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PostSubmodel/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1509,7 +1509,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PutSubmodelById]]PutSubmodelById
 h|Explanation 4+a|Replaces an existing Submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodelById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutSubmodelById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1526,7 +1526,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PatchSubmodelById]]PatchSubmodelById
 h|Explanation 4+a|Updates an existing Submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PatchSubmodelById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PatchSubmodelById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1553,7 +1553,7 @@ Note: values remain unchanged with content=metadata.
 |===
 h|Operation Name 4+e|[[DeleteSubmodelById]]DeleteSubmodelById
 h|Explanation 4+a|Deletes a Submodel
-h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteSubmodelById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteSubmodelById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1617,7 +1617,7 @@ e|xref:QueryConceptDescriptions[QueryConceptDescriptions] | Returns all Concept 
 |===
 h|Operation Name 4+e|[[GetAllConceptDescriptions]]GetAllConceptDescriptions
 h|Explanation 4+a|Returns all Concept Descriptions
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptions/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptions/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1635,7 +1635,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetConceptDescriptionById]]GetConceptDescriptionById
 h|Explanation 4+a|Returns a specific Concept Description
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetConceptDescriptionById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetConceptDescriptionById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1652,7 +1652,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetAllConceptDescriptionsByIdShort]]GetAllConceptDescriptionsByIdShort
 h|Explanation 4+a|Returns all Concept Descriptions with a specific _idShort_
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByIdShort/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByIdShort/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1671,7 +1671,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetAllConceptDescriptionsByIsCaseOf]]GetAllConceptDescriptionsByIsCaseOf
 h|Explanation 4+a|Returns all Concept Descriptions with a specific _IsCaseOf_ reference
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByIsCaseOf/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByIsCaseOf/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1690,7 +1690,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[GetAllConceptDescriptionsByDataSpecificationReference]]GetAllConceptDescriptionsByDataSpecificationReference
 h|Explanation 4+a|Returns all Concept Descriptions with a specific _dataSpecification_ reference
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByDataSpecificationReference/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByDataSpecificationReference/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1718,7 +1718,7 @@ Note: the creation of the idShort is out of scope and must be handled in a propr
 ====
 
 
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PostConceptDescription/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PostConceptDescription/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 
@@ -1739,7 +1739,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[PutConceptDescriptionById]]PutConceptDescriptionById
 h|Explanation 4+a|Replaces an existing Concept Description
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PutConceptDescriptionById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PutConceptDescriptionById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1756,7 +1756,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |===
 h|Operation Name 4+e|[[DeleteConceptDescriptionById]]DeleteConceptDescriptionById
 h|Explanation 4+a|Deletes a Concept Description
-h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteConceptDescriptionById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteConceptDescriptionById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1812,7 +1812,7 @@ e| xref:DeleteAllAssetLinksById[DeleteAllAssetLinksById]  |Deletes all asset ide
 |===
 h|Operation Name 4+e|[[GetAllAssetAdministrationShellIdsByAssetLink]]GetAllAssetAdministrationShellIdsByAssetLink
 h|Explanation 4+a|Returns a list of Asset Administration Shell ids based on asset identifier key-value-pairs
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShellIdsByAssetLink/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShellIdsByAssetLink/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1841,7 +1841,7 @@ It is the predefined key “_globalAssetId_” that would refer to the _AssetInf
 |===
 h|Operation Name 4+e|[[GetAllAssetLinksById]]GetAllAssetLinksById
 h|Explanation 4+a|Returns a list of asset identifier key-value-pairs based on an Asset Administration Shell id to edit discoverable content
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetLinksById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetLinksById/3/1`
 
 
 h|Name h|Description h|Mand. h|Type h|Card.
@@ -1871,7 +1871,7 @@ h|Operation Name 4+e|[[PostAllAssetLinksById]]PostAllAssetLinksById
 h|Explanation 4+a|
 Creates new asset identifier key-value-pairs linked to an Asset Administration Shell for discoverable content.
 The existing content might have to be deleted first.
-h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAllAssetLinksById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAllAssetLinksById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1899,7 +1899,7 @@ It is the predefined key “_globalAssetId_” that would refer to the _AssetInf
 |===
 h|Operation Name 4+e|[[DeleteAllAssetLinksById]]DeleteAllAssetLinksById
 h|Explanation 4+a|Deletes all asset identifier key-value-pairs linked to an Asset Administration Shell to edit discoverable content
-h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteAllAssetLinksById/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/DeleteAllAssetLinksById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
@@ -1926,12 +1926,12 @@ e|xref:GetSelfDescription[GetSelfDescription] |Returns a description object cont
 |===
 h|Operation Name 4+e|[[GetSelfDescription]]GetSelfDescription
 h|Explanation 4+a|Returns a description object containing the capabilities and supported features of the server.
-h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSelfDescription/3/0`
+h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSelfDescription/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|description |Key-value-pairs that describe the capabilities of the providing server |yes |ServiceDescription |1
+|description |Key-value-pairs that describe the capabilities of the providing server |yes | xref:specification/interfaces-payload.adoc#ServiceDescription[ServiceDescription] |1
 |===
 
 ====

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -516,7 +516,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetSubmodelElementValueByPath/3
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|path |{path} |yes  |Key |1..*
+|path |{path} |yes  |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Key[Key] |1..*
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |Requested submodel element value |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SubmodelElement[SubmodelElement] |1
@@ -979,7 +979,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/QueryAssetAdministrationShellDe
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|query | Query conforming to the AAS Query Language |yes | AAS Query |1
+|query | Query conforming to the AAS Query Language |yes | xref:general.adoc#query-grammar[AAS Query] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |payload |List of Asset Administration Shell Descriptors or AAS identifiers |no | xref:specification/interfaces-payload.adoc#QueryResult[QueryResult<AssetAdministrationShellDescriptor>]  |1..*
@@ -1020,7 +1020,7 @@ e|limit a|The maximum size of the result set |no |nonNegativeInteger |1
 e|cursor a|The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 e|statusCode a| StatusCode |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-e|payload a|List of requested submodel descriptors |no |SubmodelDescriptor |1..*
+e|payload a|List of requested submodel descriptors |no |xref:specification/interfaces-payload.adoc#SubmodelDescriptor[SubmodelDescriptor]  |1..*
 |===
 
 ==== Operation GetSubmodelDescriptorById
@@ -1037,7 +1037,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 e|submodelIdentifier a|The Submodel’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 e|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-e|payload a|Requested submodel descriptor |yes |SubmodelDescriptor |1
+e|payload a|Requested submodel descriptor |yes |xref:specification/interfaces-payload.adoc#SubmodelDescriptor[SubmodelDescriptor] |1
 |===
 
 ==== Operation PostSubmodelDescriptor
@@ -1221,7 +1221,7 @@ e|limit a|The maximum size of the result set |no |nonNegativeInteger |1
 e|cursor a|The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 e|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-e|payload a|List of Asset Administration Shells |no |AssetAdministrationShell |1..*
+e|payload a|List of Asset Administration Shells |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1..*
 |===
 
 ==== Operation GetAssetAdministrationShellById
@@ -1241,7 +1241,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Asset Administration Shell |yes |AssetAdministrationShell |1
+|payload |Requested Asset Administration Shell |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1
 |===
 
 ==== Operation GetAllAssetAdministrationShellsByAssetId
@@ -1262,7 +1262,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Asset Administration Shells |no |AssetAdministrationShell |1..*
+|payload |Requested Asset Administration Shells |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1..*
 |===
 
 ==== Operation GetAllAssetAdministrationShellsByIdShort
@@ -1276,13 +1276,13 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShells
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|idShort |The Asset Administration Shell’s idShort |yes |NameType | 1
+|idShort |The Asset Administration Shell’s idShort |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#NameType[NameType] | 1
 |serializationModifier |Defines the format of the response |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  | 1
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Asset Administration Shells |no |AssetAdministrationShell |1..*
+|payload |Requested Asset Administration Shells |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1..*
 |===
 
 ==== Operation PostAssetAdministrationShell
@@ -1307,13 +1307,13 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 
 5+h|Input Parameter
-|aas |Asset Administration Shell object |yes |AssetAdministrationShell |1
+|aas |Asset Administration Shell object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1
 
 5+h|Output Parameter
 
 |statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 
-|payload a|Created Asset Administration Shell |yes |AssetAdministrationShell |1
+|payload a|Created Asset Administration Shell |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1
 |===
 
 ==== Operation PutAssetAdministrationShellById
@@ -1327,10 +1327,10 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PutAssetAdministrationShellById
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|aas |Asset Administration Shell object |yes |AssetAdministrationShell |1
+|aas |Asset Administration Shell object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Replaced Asset Administration Shell |yes |AssetAdministrationShell |1
+|payload |Replaced Asset Administration Shell |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1
 |===
 
 ==== Operation DeleteAssetAdministrationShellById
@@ -1447,7 +1447,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelsBySemanticId/3/1
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|semanticId |Identifier of the semantic definition |yes |Reference |1
+|semanticId |Identifier of the semantic definition |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Reference[Reference] |1
 |serializationModifier |Defines the format of the response |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
@@ -1467,7 +1467,7 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllSubmodelsByIdShort/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|idShort |The Submodel’s idShort |yes |NameType |1
+|idShort |The Submodel’s idShort |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#NameType[NameType] |1
 |serializationModifier |Defines the format of the response |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
@@ -1622,10 +1622,10 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptions/3/1`
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
-|cursor |The position from which to resume a result listing |no |String |1
+|cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |List of Concept Descriptions |no |ConceptDescription |1..*
+|payload |List of Concept Descriptions |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1..*
 |===
 
 ==== Operation GetConceptDescriptionById
@@ -1642,7 +1642,7 @@ h|Name h|Description h|Mand. h|Type h|Card.
 |id |The Concept Description’s unique ID |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#Identifier[Identifier] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Concept Description |yes |ConceptDescription |1
+|payload |Requested Concept Description |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1
 |===
 
 ==== Operation GetAllConceptDescriptionsByIdShort
@@ -1656,12 +1656,12 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByIdSh
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|idShort |The Concept Description’s idShort |yes |NameType |1
+|idShort |The Concept Description’s idShort |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/datatypes.html#NameType[NameType] |1
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Concept Descriptions |no |ConceptDescription |1..*
+|payload |Requested Concept Descriptions |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1..*
 |===
 
 ==== Operation GetAllConceptDescriptionsByIsCaseOf
@@ -1675,12 +1675,12 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByIsCa
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|isCaseOf |IsCaseOf reference |yes |Reference |1
+|isCaseOf |IsCaseOf reference |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Reference[Reference]  |1
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode]  |1
-|payload |Requested Concept Descriptions |no |ConceptDescription |1..*
+|payload |Requested Concept Descriptions |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1..*
 |===
 
 ==== Operation GetAllConceptDescriptionsByDataSpecificationReference
@@ -1694,12 +1694,12 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllConceptDescriptionsByData
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|dataSpecification-Reference |_DataSpecification_ reference |yes |Reference |_1_
+|dataSpecification-Reference |_DataSpecification_ reference |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/referencing.html#Reference[Reference]  |_1_
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Concept Descriptions |no |ConceptDescription |1..*
+|payload |Requested Concept Descriptions |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1..*
 |===
 
 ==== Operation PostConceptDescription
@@ -1724,12 +1724,12 @@ h|Name h|Description h|Mand. h|Type h|Card.
 
 5+h|Input Parameter
 
-|conceptDescription a|Concept Description object |yes |ConceptDescription |1
+|conceptDescription a|Concept Description object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1
 
 5+h|Output Parameter
 
 |statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode]  |1
-|payload a|Created Concept Description |yes |ConceptDescription |1
+|payload a|Created Concept Description |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1
 |===
 
 ==== Operation PutConceptDescriptionById
@@ -1743,10 +1743,10 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PutConceptDescriptionById/3/1`
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|conceptDescription |Concept Description object |yes |ConceptDescription |1
+|conceptDescription |Concept Description object |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Replaced Concept Description |yes |ConceptDescription |1
+|payload |Replaced Concept Description |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/concept-description.html#ConceptDescription[ConceptDescription] |1
 |===
 
 ==== Operation DeleteConceptDescriptionById
@@ -1826,7 +1826,7 @@ It is the predefined key “_globalAssetId_” that would refer to the _AssetInf
 ====
 
 
-|no |SpecificAssetId |1..*
+|no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SpecificAssetId[SpecificAssetId] |1..*
 |limit |The maximum size of the result set |no |nonNegativeInteger |1
 |cursor |The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
@@ -1859,7 +1859,7 @@ It is the predefined name “_globalAssetId_” that would refer to the _AssetIn
 ====
 
 
-|no |SpecificAssetId |1..*
+|no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SpecificAssetId[SpecificAssetId] |1..*
 |===
 
 ==== Operation PostAllAssetLinksById
@@ -1886,10 +1886,10 @@ It is the predefined key “_globalAssetId_” that would refer to the _AssetInf
 ====
 
 
-|yes |SpecificAssetId |1..*
+|yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SpecificAssetId[SpecificAssetId] |1..*
 5+h|Output Parameter
 |statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Asset identifier created successfully |yes |SpecificAssetId |1
+|payload |Asset identifier created successfully |yes |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#SpecificAssetId[SpecificAssetId] |1
 |===
 
 ==== Operation DeleteAllAssetLinksById

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -1255,14 +1255,16 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/GetAllAssetAdministrationShells
 
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
-|key |The key of the AssetId The name of the specific asset identifier or the predefined name “_globalAssetId_” that would refer to the _AssetInformation/globalAssetId_ |yes |string |1
-|keyIdentifier |The key identifier object |yes |string |1
-|serializationModifier |Defines the format of the response |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
-|limit |The maximum size of the result set |no |nonNegativeInteger |1
-|cursor |The position from which to resume a result listing |no |string |1
+|key a|The key of the AssetId 
+
+The name of the specific asset identifier or the predefined name “_globalAssetId_” that would refer to the _AssetInformation/globalAssetId_ |yes |string |1
+|keyIdentifier a|The key identifier object |yes |string |1
+|serializationModifier a|Defines the format of the response |yes |xref:specification/interfaces-operation-parameters.adoc#SerializationModifier[SerializationModifier]  |1
+|limit a|The maximum size of the result set |no |nonNegativeInteger |1
+|cursor a|The position from which to resume a result listing |no |string |1
 5+h|Output Parameter
-|statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
-|payload |Requested Asset Administration Shells |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1..*
+|statusCode a|Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
+|payload a|Requested Asset Administration Shells |no |link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/core.html#AssetAdministrationShell[AssetAdministrationShell] |1..*
 |===
 
 ==== Operation GetAllAssetAdministrationShellsByIdShort


### PR DESCRIPTION
* major change: increase version of ID from /3/0 to /3/1 if one of the types used as parameter or output changed (also implicitly, e.g. because of changed of Identifier or NameType). However, this might lead also to new versions of https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRepositoryServiceSpecification/V3.0.3_SSP-001#/Asset%20Administration%20Shell%20Repository%20API/GetAllAssetAdministrationShells etc.
* correct type String to string
* editorial: added links to types in operations and payload classes
* correct some links
* update changelog (no new query interface) + mentioning increasing of IDs (see first point)

open: data types were restricted in length because of API, however, in interfaces.adoc still "string" is used as type instead of "Identifier" etc.: we should change this. The openAPI defined the restrictions.