### PR TITLE
Mark parameter `level` as deprecated for all URLs ending with `/$reference`

### DIFF
--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.0_SSP-001.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.0_SSP-001.yaml
@@ -991,11 +991,11 @@ paths:
       parameters:
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Limit'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Cursor'
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -1358,11 +1358,11 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetSubmodelElementByPath/3/0
       parameters:
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.0_SSP-002.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.0_SSP-002.yaml
@@ -533,6 +533,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -714,6 +715,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/AssetAdministrationShellServiceSpecification/V3.0_SSP-001.yaml
+++ b/AssetAdministrationShellServiceSpecification/V3.0_SSP-001.yaml
@@ -633,11 +633,11 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetSubmodel/3/0
       parameters:
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -851,11 +851,11 @@ paths:
       parameters:
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Limit'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Cursor'
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/AssetAdministrationShellServiceSpecification/V3.0_SSP-002.yaml
+++ b/AssetAdministrationShellServiceSpecification/V3.0_SSP-002.yaml
@@ -273,11 +273,11 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetSubmodel/3/0
       parameters:
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -455,6 +455,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/Entire-API-Collection/V3.0.yaml
+++ b/Entire-API-Collection/V3.0.yaml
@@ -578,11 +578,11 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetSubmodel/3/0
       parameters:
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -784,11 +784,11 @@ paths:
       parameters:
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Limit'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Cursor'
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -1719,11 +1719,11 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetSubmodel/3/0
       parameters:
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -1906,6 +1906,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -3619,11 +3620,11 @@ paths:
       parameters:
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Limit'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Cursor'
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -4544,6 +4545,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -5090,11 +5092,11 @@ paths:
       parameters:
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Limit'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Cursor'
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/SubmodelRepositoryServiceSpecification/V3.0_SSP-001.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.0_SSP-001.yaml
@@ -192,11 +192,11 @@ paths:
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/IdShort'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Limit'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Cursor'
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -743,6 +743,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/SubmodelRepositoryServiceSpecification/V3.0_SSP-002.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.0_SSP-002.yaml
@@ -154,11 +154,11 @@ paths:
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/IdShort'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Limit'
         - $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Cursor'
-        #- $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/parameters/Level'
         - name: level
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -494,6 +494,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/SubmodelServiceSpecification/V3.0_SSP-001.yaml
+++ b/SubmodelServiceSpecification/V3.0_SSP-001.yaml
@@ -286,6 +286,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -480,6 +481,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -856,6 +858,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/SubmodelServiceSpecification/V3.0_SSP-002.yaml
+++ b/SubmodelServiceSpecification/V3.0_SSP-002.yaml
@@ -133,6 +133,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -289,6 +290,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core
@@ -453,6 +455,7 @@ paths:
           in: query
           description: Determines the structural depth of the respective resource content
           required: false
+          deprecated: true
           schema:
             type: string
             default: core

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ Major Changes:
 * Transfer of chapters on formats Metadata, Paths and Value-Only from Part 2 API to Part 1 Metamodel (https://github.com/admin-shell-io/aas-specs-api/issues/214[#214])
 * Transfer from .docx to asciidoc (.adoc) and maintenance in GitHub
 * Transfer of all UML figures to PlantUML (.puml) and maintenance in GitHub
+* Swagger: marked parameter 'level' as deprecated for all URLs ending with '/$reference'
 
 Minor Changes:
 


### PR DESCRIPTION
Fixes #223 