### PR TITLE
Add Missing Bulk Descriptions

### DIFF
--- a/AssetAdministrationShellRegistryServiceSpecification/V3.1_SSP-003.yaml
+++ b/AssetAdministrationShellRegistryServiceSpecification/V3.1_SSP-003.yaml
@@ -35,10 +35,10 @@ paths:
       summary: >-
         Creates multiple new Asset Administration Shell Descriptors, i.e.
         registers multiple Asset Administration Shells
-      operationId: BulkPostAssetAdministrationShellDescriptor
+      operationId: CreateBulkAssetAdministrationShellDescriptors
       x-semanticIds:
         - >-
-          https://admin-shell.io/aas/API/BulkPostAssetAdministrationShellDescriptor/3/1
+          https://admin-shell.io/aas/API/CreateBulkAssetAdministrationShellDescriptors/3/1
       requestBody:
         description: List of Asset Administration Shell Descriptor objects
         content:
@@ -69,10 +69,10 @@ paths:
       tags:
         - Async Bulk Asset Administration Shell Registry API
       summary: Updates multiple existing Asset Administration Shell Descriptors
-      operationId: BulkPutAssetAdministrationShellDescriptorById
+      operationId: PutBulkAssetAdministrationShellDescriptorsById
       x-semanticIds:
         - >-
-          https://admin-shell.io/aas/API/BulkPutAssetAdministrationShellDescriptorById/3/1
+          https://admin-shell.io/aas/API/PutBulkAssetAdministrationShellDescriptorsById/3/1
       requestBody:
         description: List of Asset Administration Shell Descriptor objects
         content:
@@ -105,12 +105,12 @@ paths:
       summary: >-
         Deletes multiple Asset Administration Shell Descriptors, i.e.
         de-registers multiple Asset Administration Shells
-      operationId: BulkDeleteAssetAdministrationShellDescriptorById
+      operationId: DeleteBulkAssetAdministrationShellDescriptorsById
       x-semanticIds:
         - >-
-          https://admin-shell.io/aas/API/BulkDeleteAssetAdministrationShellDescriptorById/3/1
+          https://admin-shell.io/aas/API/DeleteBulkAssetAdministrationShellDescriptorsById/3/1
       requestBody:
-        description: List of Asset Administration Shell’s unique ids
+        description: List of Asset Administration Shell's unique ids
         content:
           application/json:
             schema:
@@ -139,9 +139,9 @@ paths:
       tags:
         - Async Bulk Status API
       summary: Returns the status of an asynchronously invoked bulk operation
-      operationId: BulkGetAsyncStatus
+      operationId: GetAsyncBulkStatus
       x-semanticIds:
-        - https://admin-shell.io/aas/API/BulkGetAsyncStatus/3/1
+        - https://admin-shell.io/aas/API/GetAsyncBulkStatus/3/1
       parameters:
         - in: path
           name: handleId
@@ -184,7 +184,9 @@ paths:
       tags:
         - Async Bulk Result API
       summary: Returns the result object of an asynchronously invoked bulk operation
-      operationId: BulkGetAsyncResult
+      operationId: GetBulkAsyncResult
+      x-semanticIds:
+        - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/1
       parameters:
         - in: path
           name: handleId

--- a/SubmodelRegistryServiceSpecification/V3.1_SSP-003.yaml
+++ b/SubmodelRegistryServiceSpecification/V3.1_SSP-003.yaml
@@ -32,9 +32,9 @@ paths:
       tags:
         - Async Bulk Submodel Registry API
       summary: Creates multiple new Submodel Descriptors
-      operationId: BulkPostSubmodel
+      operationId: CreateBulkSubmodelDescriptors
       x-semanticIds:
-        - https://admin-shell.io/aas/API/BulkPostSubmodelDescriptor/3/1
+        - https://admin-shell.io/aas/API/CreateBulkSubmodelDescriptors/3/1
       requestBody:
         description: List of Submodel Descriptor objects
         content:
@@ -65,9 +65,9 @@ paths:
       tags:
         - Async Bulk Submodel Registry API
       summary: Updates multiple existing Submodel Descriptors
-      operationId: BulkPutSubmodelDescriptorsById
+      operationId: PutBulkSubmodelDescriptorsById
       x-semanticIds:
-        - https://admin-shell.io/aas/API/BulkPutSubmodelDescriptorsById/3/1
+        - https://admin-shell.io/aas/API/PutBulkSubmodelDescriptorsById/3/1
       requestBody:
         description: List of Submodel Descriptor objects
         content:
@@ -99,19 +99,18 @@ paths:
       tags:
         - Async Bulk Submodel Registry API
       summary: Deletes multiple Submodel Descriptors
-      operationId: BulkDeleteSubmodelDescriptorsById
+      operationId: DeleteBulkSubmodelDescriptorsById
       x-semanticIds:
-        - https://admin-shell.io/aas/API/BulkDeleteSubmodelDescriptorsById/3/1
+        - https://admin-shell.io/aas/API/DeleteBulkSubmodelDescriptorsById/3/1
       requestBody:
-        description: List of Submodel Descriptor Identifiers
+        description: List of Submodel Identifiers
         content:
           application/json:
             schema:
               type: array
               minItems: 1
               items:
-                $ref: >-
-                  #/components/parameters/SubmodelIdentifier
+                type: string
       responses:
         '202':
           $ref: >-
@@ -133,9 +132,9 @@ paths:
       tags:
         - Async Bulk Status API
       summary: Returns the status of an asynchronously invoked bulk operation
-      operationId: BulkGetAsyncStatus
+      operationId: GetBulkAsyncStatus
       x-semanticIds:
-        - https://admin-shell.io/aas/API/BulkGetAsyncStatus/3/1
+        - https://admin-shell.io/aas/API/GetBulkAsyncStatus/3/1
       parameters:
         - in: path
           name: handleId
@@ -179,7 +178,9 @@ paths:
       tags:
         - Async Bulk Result API
       summary: Returns the result object of an asynchronously invoked bulk operation
-      operationId: BulkGetAsyncResult
+      operationId: GetBulkAsyncResult
+      x-semanticIds:
+        - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/1
       parameters:
         - in: path
           name: handleId

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -600,6 +600,21 @@ assetType= base64url-encoded identifier
 |DeleteAssetAdministrationShellDescriptorById |DELETE |/shell-descriptors/\{aasIdentifier} |base64url-encoded identifier
 |Submodel Registry Interface |* |/shell-descriptors/\{aasIdentifier}/submodelDescriptors/* |superpath as defined in Service Specification or Profile
 |QueryAssetAdministrationShellDescriptors |POST |/query/shell-descriptors a| Input query in the request body
+|CreateBulkAssetAdministrationShellDescriptors |POST |/bulk/shell-descriptors a| List of new Asset Administration Shell Descriptors in the request body
+|PutBulkAssetAdministrationShellDescriptorsById |PUT |/bulk/shell-descriptors a| List of new versions of Asset Administration Shell Descriptors in the request body. Mapping to existing Asset Administration Shell Descriptors happens via the `id` attribute.
+|DeleteBulkAssetAdministrationShellDescriptorsById |DELETE |/bulk/shell-descriptors a| List of Asset Administration Shell identifiers in the request body
+|GetBulkAsyncStatus |GET |/bulk/status/{handleId} a| Server-side defined handle to retrieve the status of a previous bulk request.
+
+====
+Note: Same endpoint as for the Submodel Registry Interface bulk status. 
+====
+
+|GetBulkAsyncResult |GET |/bulk/status/{handleId} a| Server-side defined handle to retrieve the result of a previous bulk request.
+
+====
+Note: Same endpoint as for the Submodel Registry Interface bulk result. 
+====
+
 |*Submodel Registry Interface* | | |
 |GetAllSubmodelDescriptors |GET |/submodel-descriptors |Pagination
 |GetSubmodelDescriptorById |GET |/submodel-descriptors/\{submodelIdentifier} |base64url-encoded identifier
@@ -607,6 +622,21 @@ assetType= base64url-encoded identifier
 |PutSubmodelDescriptorById |PUT |/submodel-descriptors/\{submodelIdentifier} |base64url-encoded identifier
 |DeleteSubmodelDescriptorById |DELETE |/submodel-descriptors/\{submodelIdentifier} |base64url-encoded identifier
 |QuerySubmodelDescriptors |POST |/query/submodel-decriptors a| Input query in the request body
+|CreateBulkSubmodelDescriptors |POST |/bulk/submodel-descriptors a| List of new Submodel Descriptors in the request body
+|PutBulkSubmodelDescriptorsById |PUT |/bulk/submodel-descriptors a| List of new versions of Submodel Descriptors in the request body. Mapping to existing Submodel Descriptors happens via the `id` attribute.
+|DeleteBulkSubmodelDescriptorsById |DELETE |/bulk/submodel-descriptors a| List of Submodel identifiers in the request body
+|GetBulkAsyncStatus |GET |/bulk/status/{handleId} a| Server-side defined handle to retrieve the status of a previous bulk request.
+
+====
+Note: Same endpoint as for the Asset Administration Shell Registry Interface bulk status. 
+====
+
+|GetBulkAsyncResult |GET |/bulk/status/{handleId} a| Server-side defined handle to retrieve the result of a previous bulk request.
+
+====
+Note: Same endpoint as for the Asset Administration Shell Registry Interface bulk result. 
+====
+
 |*Descriptor Interface* | | |
 |GetDescription |GET |/description |Provide additional information on interface endpoint; may also be used at a server endpoint to list all descriptions available on that server
 |===


### PR DESCRIPTION
Addresses these comments:
- [Missing bulk mappings for http](https://github.com/admin-shell-io/aas-specs-api/pull/221#discussion_r1903128283)
- [Wrong operationIds / x-semanticIds for bulk operations in the OpenAPI files](https://github.com/admin-shell-io/aas-specs-api/pull/221#discussion_r1903127815)

Before merging:
- [ ] #380 has to be merged
- [ ] #381 has to be merged
- [ ] Entire API V3.1 requires the changes to the bulk endpoints as well (not yet part of the branch as the two merges above are required first)