### PR TITLE
Change ProtocolInformation/securityAttributes from mandatory to optional

### DIFF
--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -785,7 +785,6 @@ components:
           minItems: 1
       required: 
         - href
-        - securityAttributes
       type: object
     Query:
       type: object

--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -785,6 +785,7 @@ components:
           minItems: 1
       required: 
         - href
+        - securityAttributes
       type: object
     Query:
       type: object

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,7 +28,8 @@ Major Changes:
 * Transfer of chapters on formats Metadata, Paths and Value-Only from Part 2 API to Part 1 Metamodel (https://github.com/admin-shell-io/aas-specs-api/issues/214[#214])
 * Transfer from .docx to asciidoc (.adoc) and maintenance in GitHub
 * Transfer of all UML figures to PlantUML (.puml) and maintenance in GitHub
-* Swagger: marked parameter 'level' as deprecated for all URLs ending with '/$reference'
+* OpenAPI: marked parameter 'level' as deprecated for all URLs ending with '/$reference'
+* OpenAPI: ProtocolInformation/securityAttributes has always been mandatory but was not in the list of required attributes in the OpenAPI file. 
 
 Minor Changes:
 
@@ -140,6 +141,8 @@ added new API-operation SearchAllAssetAdministrationShellIdsByAssetLink
 | | xref:http-rest-api/http-rest-api.adoc#PackageDescription[PackageDescription/aasIds] a| data type: change length from 2000 to 2048 characters
 
 | | xref:specification/interfaces-payload.adoc#ProtocolInformation[ProtocolInformation/href] a| data type: change length from 2000 to 2048 characters
+
+| | xref:specification/interfaces-payload.adoc#ProtocolInformation[ProtocolInformation/securityAttributes] a| Added to the list of required attributes in OpenAPI as it was declared as a mandatory attribute since V3.0
 |===
 
 .New Data Types for Payload

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -29,7 +29,7 @@ Major Changes:
 * Transfer from .docx to asciidoc (.adoc) and maintenance in GitHub
 * Transfer of all UML figures to PlantUML (.puml) and maintenance in GitHub
 * OpenAPI: marked parameter 'level' as deprecated for all URLs ending with '/$reference'
-* OpenAPI: ProtocolInformation/securityAttributes has always been mandatory but was not in the list of required attributes in the OpenAPI file. 
+* ProtocolInformation/securityAttributes changed from mandatory to optional. 
 
 Minor Changes:
 
@@ -142,7 +142,7 @@ added new API-operation SearchAllAssetAdministrationShellIdsByAssetLink
 
 | | xref:specification/interfaces-payload.adoc#ProtocolInformation[ProtocolInformation/href] a| data type: change length from 2000 to 2048 characters
 
-| | xref:specification/interfaces-payload.adoc#ProtocolInformation[ProtocolInformation/securityAttributes] a| Added to the list of required attributes in OpenAPI as it was declared as a mandatory attribute since V3.0
+| | xref:specification/interfaces-payload.adoc#ProtocolInformation[ProtocolInformation/securityAttributes] a| Changed securityAttributes from `mandatory` to `optional`. OpenAPI remains unchanged. (https://github.com/admin-shell-io/aas-specs-api/issues/384[#384])
 |===
 
 .New Data Types for Payload

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-payload.adoc
@@ -208,7 +208,7 @@ Array of securityAttribute objects, each attribute has 3 properties:
 
 The securityAttribute objects are treated as possible alternatives (logical “or”)
 
-|xref:SecurityAttributeObject[SecurityAttributeObject] |1..*
+|xref:SecurityAttributeObject[SecurityAttributeObject] |0..*
 |===
 
 [.table-with-appendix-table]


### PR DESCRIPTION
For some reason, `ProtocolInformation/securityAttributes` was never in the list of required attributes. However, the specification always demanded it since version 3.0:

![image](https://github.com/user-attachments/assets/1fa12293-07b3-4985-a1df-b6d4c4f2399e)

This is therefore an important bugfix to keep the OpenAPI declaration in sync with the specification text.