### PR TITLE
Add editorial notes to TOC

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/nav.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/nav.adoc
@@ -37,6 +37,7 @@ Shared .adoc file are used from https://github.com/admin-shell-io/aas-specs
 
 ////
 
+* xref:index.adoc[Editorial Notes]
 
 * xref:terms-definitions-and-abbreviations.adoc[Terms and Definitions]
 


### PR DESCRIPTION
This change is required to set line numbers in the generated PDF document from the first page.

The code for setting line numbers works based on nav.adoc. It starts with the first dodument referenced in nav.adoc and sets line numbers there.