### PR TITLE
Updated swagger links in http-rest-api.adoc

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -22,12 +22,12 @@ To clearly separate the different parts of the AAS model, the model has been spl
 Combinations then form service specifications and profiles, each materialized as an individual OpenAPI document.
 
 The schema for the metamodel of Part 1 is available at: +
-https://app.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1#[https://app.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1#] +
+https://app.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#[https://app.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.0#] +
 This schema includes general objects, which are used in the further defined APIs.
 
 Additional objects are needed for Part 2, e.g., the Descriptors for the Registry.
 The related schema of Part 2 objects is available at: +
-https://app.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1#[https://app.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1#] +
+https://app.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#[https://app.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#] +
 This schema includes general objects, which are used in the further defined APIs.
 
 The AAS Service Specification including the AAS API, the Submodel API, the Serialization API, and the Self-Description API is available at: +


### PR DESCRIPTION
Links to metamodel and part2 api pointed to v3.1 instead v3.1.0