### PR TITLE
Adjust Entries in Operations Table

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -409,7 +409,7 @@ path-suffix= $metadata/$value/$reference/$path or no suffix for normal
 |GetAllSubmodelElements |GET |/submodel/submodel-elements a|
 ?level=deep/core
 
-path-suffix= $metadata/$value/$reference/$path or no suffix for nomal
+path-suffix= $metadata/$value/$reference/$path or no suffix for normal
 
 ?extent=WithoutBLOBValue/WithBLOBValue
 
@@ -420,10 +420,12 @@ use separated idShortPath of this element
 
 ?level=deep/core
 
-path-suffix= $metadata/$value/$reference/$path or no suffix for nomal +
+path-suffix= $metadata/$value/$reference/$path or no suffix for normal +
 ?extent=WithoutBLOBValue/WithBLOBValue
 
-*Note:* If a client uses a path-suffix for a SubmodelElement that has the associated Serialisation Modifier not defined (e.g. .../capabilityIdShort/$value), a server shall respond with a ClientErrorBadRequest (HTTP status code 400) and an appropriate error description in the response message.
+====
+Note: If a client uses a path-suffix for a SubmodelElement that has the associated Serialisation Modifier not defined (e.g. .../capabilityIdShort/$value), a server shall respond with a ClientErrorBadRequest (HTTP status code 400) and an appropriate error description in the response message.
+====
 
 URL-encoded IdShortPath
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -366,9 +366,7 @@ Note: Although metadata and value-only representations of Asset Administration S
 
 The following <<table-mapping-operations>> shows the mapping of the generic operations to the HTTP/REST API.
 
-The black entries correspond to the corresponding generic operations.
-
-[.blue]#The blue entries are operations which only exist in the HTTP/REST API.#
+All entries correspond to the generic operations, except the *bold* entries, which exist only in the HTTP/REST API.
 
 [[table-mapping-operations]]
 .Mapping of the generic Interface Operations to HTTP API Operations
@@ -394,7 +392,7 @@ Note 2: There is no API defined for a client to directly send a GET towards this
 |GetThumbnail |GET |/aas/asset-information/thumbnail |
 |PutThumbnail |PUT |/aas/asset-information/thumbnail |
 |DeleteThumbnail |DELETE |/aas/asset-information/thumbnail |
-| |* |/aas/submodels/\{submodel-identifier}/* |superpath as defined in service specification or profile
+s| s|* s|/aas/submodels/\{submodel-identifier}/* s|superpath as defined in service specification or profile
 
 4+h|Submodel Interface
 |GetSubmodel |GET |/submodel a|
@@ -529,7 +527,7 @@ path-suffix=$reference or no suffix normal
 |PostAssetAdministrationShell |POST |/shells |
 |PutAssetAdministrationShellById |PUT |/shells/\{aasIdentifier} |base64url-encoded identifier
 |DeleteAssetAdministrationShellById |DELETE |/shells/\{aasIdentifier} |base64url-encoded identifier
-|AasInterface |* |/shells/\{aasIdentifier}/* |superpath as defined in Service Specification or Profile
+s|AasInterface s|* s|/shells/\{aasIdentifier}/* s|superpath as defined in Service Specification or Profile
 |QueryAssetAdministrationShells |POST |/query/shells a| Input query in the request body
 
 4+h|Submodel Repository Interface
@@ -561,7 +559,7 @@ base64url-encoded identifier
 |PutSubmodelById |PUT |/submodels/\{submodelIdentifier} |base64url-encoded identifier
 |PatchSubmodelById |PATCH |/submodels/\{submodelIdentifier} |path-suffix=$metadata/$value or no suffix for normal
 |DeleteSubmodelById |DELETE |/submodels/\{submodelIdentifier} |base64url-encoded identifier
-|SubmodelInterface |* |/submodels/\{submodelIdentifier}/* |superpath as defined in service specification or profile
+s|SubmodelInterface s|* s|/submodels/\{submodelIdentifier}/* s|superpath as defined in service specification or profile
 |QuerySubmodels |POST |/query/submodels a| Input query in the request body
 
 4+h|Concept Description Repository Interface
@@ -626,7 +624,7 @@ assetType= base64url-encoded identifier
 |PostAssetAdministrationShellDescriptorById |POST |/shell-descriptors/\{aasIdentifier} |base64url-encoded identifier
 |PutAssetAdministrationShellDescriptorById |PUT |/shell-descriptors/\{aasIdentifier} |base64url-encoded identifier
 |DeleteAssetAdministrationShellDescriptorById |DELETE |/shell-descriptors/\{aasIdentifier} |base64url-encoded identifier
-|Submodel Registry Interface |* |/shell-descriptors/\{aasIdentifier}/submodelDescriptors/* |superpath as defined in Service Specification or Profile
+s|Submodel Registry Interface s|* s|/shell-descriptors/\{aasIdentifier}/submodelDescriptors/* s|superpath as defined in Service Specification or Profile
 |QueryAssetAdministrationShellDescriptors |POST |/query/shell-descriptors a| Input query in the request body
 |CreateBulkAssetAdministrationShellDescriptors |POST |/bulk/shell-descriptors a| List of new Asset Administration Shell Descriptors in the request body
 |PutBulkAssetAdministrationShellDescriptorsById |PUT |/bulk/shell-descriptors a| List of new versions of Asset Administration Shell Descriptors in the request body. Mapping to existing Asset Administration Shell Descriptors happens via the `id` attribute.
@@ -666,7 +664,7 @@ Note: Same endpoint as for the Asset Administration Shell Registry Interface bul
 ====
 
 4+h|Descriptor Interface
-|GetDescription |GET |/description |Provide additional information on interface endpoint; may also be used at a server endpoint to list all descriptions available on that server
+s|GetDescription s|GET s|/description s|Provide additional information on interface endpoint; may also be used at a server endpoint to list all descriptions available on that server
 |===
 
 [#async-invocation-of-se-operation]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -418,7 +418,7 @@ use separated idShortPath of this element
 
 ?level=deep/core
 
-path-suffix= $metadata/$value/$reference/$path or no suffix for normal +
+path-suffix= $metadata/$value/$reference/$path or no suffix or serialization modifier "Normal" +
 ?extent=WithoutBLOBValue/WithBLOBValue
 
 ====

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -407,7 +407,7 @@ path-suffix= $metadata/$value/$reference/$path or no suffix for normal
 |GetAllSubmodelElements |GET |/submodel/submodel-elements a|
 ?level=deep/core
 
-path-suffix= $metadata/$value/$reference/$path or no suffix for normal
+path-suffix= $metadata/$value/$reference/$path or no suffix for serialization modifier "Normal"
 
 ?extent=WithoutBLOBValue/WithBLOBValue
 


### PR DESCRIPTION
Previously, blue entries were mentioned for operations that exist only in the HTTP/REST API. However, there were no blue entries in the table.

In this PR, the sentences have been corrected, and now the entries are bold. The corresponding entries in the table have been adjusted accordingly.