### PR TITLE
bugfix Constraint AASa-004 und editorial changes

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -61,15 +61,16 @@ The following design decisions and constraints hold for the HTTP/REST API:
 This leads to the constraint that one operation can only provide one type of a resulting payload.
 * This document assumes version 1.1 of HTTP.
 * An endpoint of the HTTP/REST API shall always use HTTPS (Port 443) with an up-to-date level of encryption.
-* The SerializationModifier "content" changes the type the of payload for inputs or results.
-To ensure type-safe APIs, this parameter is mapped to the path suffixes "/$value", "/$metadata", "/$reference", and "/$path". "content=Normal" is mapped to the path without any "/$<content>" suffix.
+* The SerializationModifier xref:specification/interfaces-operation-parameters.adoc#enumeration-content["Content"] changes the type the of payload for inputs or results.
+To ensure type-safe APIs, this parameter is mapped to the path suffixes "/$value", "/$metadata", "/$reference", and "/$path". Content="Normal" is mapped to the path without any "/$<content>" suffix.
 * Generic SerializationModifiers changing the size of payload for input or result have been mapped to corresponding query parameters, e.g. "?level=" or "?extent=".
 * Query parameters are also used when the type of a resulting payload is a list of objects and the type remains the same, while the query parameter filters the content of the list, e.g. GetAllSubmodels with optional query parameters "?semanticId=" or "?idShort=".
 * Complete objects are provided as requested payloads, e.g. a complete submodel.
-This corresponds to the generic SerializationModifier content="Normal".
+This corresponds to the generic SerializationModifier Content="Normal".
 Reduced objects can be requested by the path suffix "/$<content>".
-// Previously pointing to Clause 12.5
+
 See xref:bibliography.adoc#bib1[[1]] for further details.
+
 Exceptions to this rule are API Operations requiring pagination and error cases.
 * By default, blobs are not part of the payload.
 Using ?extent=WithBLOBValue includes blobs for submodel elements of kind BLOB.
@@ -337,26 +338,26 @@ Additional classes needed for payload of the HTTP/REST API specification can be 
 == Modifier Constraints
 
 
-To use link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/mappings/mappings.html#_format_metadata_metadata_serialization[metadata objects] as described in xref:bibliography.adoc#bib1[[1]], xref:specifiction/interfaces-operation-parameters.adoc[modifiers] are implemented as HTTP query parameters or path suffixes.
+To use link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/mappings/mappings.html#_format_metadata_metadata_serialization[metadata objects] as described in xref:bibliography.adoc#bib1[[1]], xref:specification/interfaces-operation-parameters.adoc[modifiers] are implemented as HTTP query parameters or path suffixes.
 For example, a request for a specific submodel may look like: +
-GET /submodel/$value?level=deep&extent=withBlobValue
+GET /submodel/$value?level=deep&extent="withBlobValue"
 
 The following constraints apply for the combination of modifiers:
 
-* For Content=Value, the requested object shall always be serialized to an unnamed JSON Object or Array.
+* For Content="Value", the requested object shall always be serialized to an unnamed JSON Object or Array.
 This means that the response object must not have a property with the object’s idShort at the root level.
-* If Level=Core and Content=Value, only the requested object and the direct children without their value (empty value) will be returned in value serialization.
+* If Level="Core" and Content="Value", only the requested object and the direct children without their value (empty value) will be returned in value serialization.
 If a direct child is a SubmodelElementCollection, "<SubmodelElementCollection/idShort>": `{}` will be returned.
 If a direct child is a SubmodelElementList, "<SubmodelElementList/idShort>": `[]` will be returned.
-* The combination of Content=Metadata and Extent=WithBLOBValue is not allowed.
+* The combination of Content="Metadata" and Extent="WithBLOBValue" is not allowed.
 * If parameter Content is set to "Metadata" then Level shall not be used.
 A server shall respond with a ClientErrorBadRequest in this case.
-* The combination of Level=Deep and Content=Reference is not allowed.
+* The combination of Level="Deep" and Content="Reference" is not allowed.
 * Modifiers cannot be used for POST operations.
 
 In addition, the modifiers can also be used for PUT operations.
 They define how the request content is delivered and have the same semantics as in the related GET operation.
-Only Content=Reference and Content=Path are not possible for PUT.
+Only Content="Reference" and Content="Path" are not possible for PUT.
 
 ====
 Note: Although metadata and value-only representations of Asset Administration Shells are possible, they are not supported up to now.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -15,7 +15,7 @@ include::../includes/constraints.adoc[]
 [#service-specifications-and-profiles]
 = Service Specifications and Profiles
 
-xref:general.adoc#image-i40-service-model[] in Clause xref:general.adoc[] defines that a service specification contains at least one API and that an API contains at least one API Operation.
+xref:general.adoc#image-i40-service-model[Figure 1] in Clause xref:general.adoc[] defines that a service specification contains at least one API and that an API contains at least one API Operation.
 
 The profiles defined in this clause present complete service specifications and their subsets.
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -1053,7 +1053,7 @@ See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpec
 [cols="59%,41%"]
 |===
 h|Service Specification / Profiles h|Description
-|<<concept-description-repository-service-specification-service-specification-ssp-001ConceptDescriptionRepositoryServiceSpecification/SSP-001>> |Full feature set
+|<<concept-description-repository-service-specification-service-specification-ssp-001,ConceptDescriptionRepositoryServiceSpecification/SSP-001>> |Full feature set
 |<<concept-description-repository-service-specification-service-specification-ssp-002,ConceptDescriptionRepositoryServiceSpecification/SSP-002>> |Query operations
 |===
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -76,8 +76,8 @@ Note: in the following, only the last part (<name of service specification>/SSP-
 [%autowidth,width="100%",cols="45%,55%",options="header",]
 |===
 h|Service Specification / Profiles h|Description
-|AssetAdministrationShellServiceSpecification/SSP-001 |Full feature set
-|AssetAdministrationShellServiceSpecification/SSP-002 |Only read operations; is included in the profile AssetAdministrationShellServiceSpecification/SSP-001.
+|<<asset-administration-shell-service-specification-SSP-001,AssetAdministrationShellServiceSpecification/SSP-001>> |Full feature set
+|<<asset-administration-shell-service-specification-SSP-002,AssetAdministrationShellServiceSpecification/SSP-002>> |Only read operations; is included in the profile AssetAdministrationShellServiceSpecification/SSP-001.
 |===
 
 [#asset-administration-shell-service-specification-SSP-001]
@@ -186,9 +186,9 @@ See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellServi
 [%autowidth,width="100%",options="header",]
 |===
 h|Service Specification / Profiles |Description
-|SubmodelServiceSpecification/SSP-001 |Full feature set
-|SubmodelServiceSpecification/SSP-002 |Only reads operations; is included in the profile SubmodelServiceSpecification/SSP-001.
-|SubmodelServiceSpecification/SSP-003 |Limitation on the basic capabilities plus the option to execute synchronous operations and to read the submodel in the ValueOnly-serialization format to reduce required bandwidth; is included in the profile SubmodelServiceSpecification/SSP-001.
+|<<submodel-service-specification-SSP-001,SubmodelServiceSpecification/SSP-001>> |Full feature set
+|<<submodel-service-specification-SSP-002,SubmodelServiceSpecification/SSP-002>> |Only reads operations; is included in the profile SubmodelServiceSpecification/SSP-001.
+|<<submodel-service-specification-SSP-003,SubmodelServiceSpecification/SSP-003>> |Limitation on the basic capabilities plus the option to execute synchronous operations and to read the submodel in the ValueOnly-serialization format to reduce required bandwidth; is included in the profile SubmodelServiceSpecification/SSP-001.
 |===
 
 [#submodel-service-specification-SSP-001]
@@ -307,14 +307,16 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelServiceSpecification/V3.1.0_SSP-003[https://app.swaggerhub.com/apis/Plattform_i40/SubmodelServiceSpecification/V3.1.0_SSP-003]
 
+[#aasx-file-server-service-specification]
 == AASX File Server Service Specification
 
 [%autowidth,width="100%",cols="45%,55%",options="header",]
 |===
 h|Service Specification / Profiles h|Description
-|AasxFileServerServiceSpecification/SSP-001 |The full feature set of the AASX File Server Service Specification
+|<<aasx-file-server-service-specification-SSP-001, AasxFileServerServiceSpecification/SSP-001>>The full feature set of the AASX File Server Service Specification
 |===
 
+[#aasx-file-server-service-specification-SSP-001]
 === AASX File Server Service Specification – Full Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -344,17 +346,19 @@ AASX for packages
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AasxFileServerServiceSpecification/V3.1.0_SSP-001
 
+[#asset-administration-shell-registry-service-specification]
 == Asset Administration Shell Registry Service Specification
 
 [%autowidth,width="100%",options="header",]
 |===
 h|Service Specification / Profiles h|Description
-|AssetAdministrationShellRegistryServiceSpecification/SSP-001 |Full profile
-|AssetAdministrationShellRegistryServiceSpecification/SSP-002 |Only reads operations; is included in the profile AssetAdministrationShellRegistryServiceSpecification/SSP-001.
-|AssetAdministrationShellRegistryServiceSpecification/SSP-003 |Bulk write and delete operations.
-|AssetAdministrationShellRegistryServiceSpecification/SSP-004 |Query operations.
+|<<asset-administration-shell-registry-service-specification-ssp-001,AssetAdministrationShellRegistryServiceSpecification/SSP-001>> |Full profile
+|<<asset-administration-shell-registry-service-specification-ssp-002,AssetAdministrationShellRegistryServiceSpecification/SSP-002>> |Only reads operations; is included in the profile AssetAdministrationShellRegistryServiceSpecification/SSP-001.
+|<<asset-administration-shell-registry-service-specification-ssp-003,AssetAdministrationShellRegistryServiceSpecification/SSP-003>> |Bulk write and delete operations.
+|<<asset-administration-shell-registry-service-specification-ssp-004,AssetAdministrationShellRegistryServiceSpecification/SSP-004>> |Query operations.
 |===
 
+[#asset-administration-shell-registry-service-specification-ssp-001]
 === Asset Administration Shell Registry Service Specification – Full Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -387,6 +391,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRegistryServiceSpecification/V3.1.0_SSP-001
 
+[#asset-administration-shell-registry-service-specification-ssp-002]
 === Asset Administration Shell Registry Service Specification – Read Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -413,6 +418,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRegistryServiceSpecification/V3.1.0_SSP-002
 
+[#asset-administration-shell-registry-service-specification-ssp-003]
 === Asset Administration Shell Registry Service Specification – Bulk Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -436,6 +442,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRegistryServiceSpecification/V3.1.0_SSP-003
 
+[#asset-administration-shell-registry-service-specification-ssp-004]
 === Asset Administration Shell Registry Service Specification – Query Profile
 
 [%autowidth, width="100%", cols="36%,64%",options="header",]
@@ -458,17 +465,19 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRegistryServiceSpecification/V3.1.0_SSP-004
 
+[#submodel-registry-service-specification]
 == Submodel Registry Service Specification
 
 [%autowidth,width="100%",options="header",]
 |===
 h|Service Specification / Profiles h|Description
-|SubmodelRegistryServiceSpecification/SSP-001 |Full profile
-|SubmodelRegistryServiceSpecification/SSP-002 |Only reads operations; is included in the profile SubmodelRegistryServiceSpecification/SSP-001.
-|SubmodelRegistryServiceSpecification/SSP-003 |Bulk write and delete operations.
-|SubmodelRegistryServiceSpecification/SSP-004 |Query operations.
+|<<submodel-registry-service-specification-ssp-001,SubmodelRegistryServiceSpecification/SSP-001>> |Full profile
+|<<submodel-registry-service-specification-ssp-002,SubmodelRegistryServiceSpecification/SSP-002>> |Only reads operations; is included in the profile SubmodelRegistryServiceSpecification/SSP-001.
+|<<submodel-registry-service-specification-ssp-003,SubmodelRegistryServiceSpecification/SSP-003>> |Bulk write and delete operations.
+|<<submodel-registry-service-specification-ssp-004,SubmodelRegistryServiceSpecification/SSP-004>> |Query operations.
 |===
 
+[#submodel-registry-service-specification-ssp-001]
 === Submodel Registry Service Specification – Full Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -494,6 +503,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRegistryServiceSpecification/V3.1.0_SSP-001
 
+[#submodel-registry-service-specification-ssp-002]
 === Submodel Registry Profile – Read Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -516,6 +526,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRegistryServiceSpecification/V3.1.0_SSP-002
 
+[#submodel-registry-service-specification-ssp-003]
 === Submodel Registry Profile – Bulk Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -539,6 +550,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRegistryServiceSpecification/V3.1.0_SSP-003
 
+[#submodel-registry-service-specification-ssp-004]
 === Submodel Registry Profile – Query Profile
 
 [%autowidth, width="100%", cols="36%,64%",options="header",]
@@ -561,15 +573,17 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRegistryServiceSpecification/V3.1.0_SSP-004
 
+[#discovery-service-specification-ssp]
 == Discovery Service Specification
 
 [%autowidth,width="100%",cols="43%,57%",options="header",]
 |===
 h|Service Specification / Profiles h|Description
-|DiscoveryServiceSpecification/SSP-001 |Full feature set
-|DiscoveryServiceSpecification/SSP-002 |only read operations; does not contain the deprecated read operation from DiscoveryServiceSpecification/SSP-001
+|<<discovery-service-specification-ssp-001,DiscoveryServiceSpecification/SSP-001>> |Full feature set
+|<<discovery-service-specification-ssp-002,DiscoveryServiceSpecification/SSP-002>> |only read operations; does not contain the deprecated read operation from DiscoveryServiceSpecification/SSP-001
 |===
 
+[#discovery-service-specification-ssp-001]
 === Discovery Service Specification – Full Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -595,6 +609,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/DiscoveryServiceSpecification/V3.1.0_SSP-001
 
+[#discovery-service-specification-ssp-002]
 === Discovery Service Specification – Read Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -618,19 +633,18 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/DiscoveryServiceSpecification/V3.1.0_SSP-002
 
+[#asset-administration-shell-repository-service-specification-service-specification]
 == Asset Administration Shell Repository Service Specification
 
 [%autowidth,width="100%",cols="42%,58%",options="header",]
 |===
 h|Service Specification / Profiles h|Description
-|AssetAdministrationShellRepository +
-ServiceSpecification/SSP-001 |Full feature set
-|AssetAdministrationShellRepository +
-ServiceSpecification/SSP-002 |Only read operations; is included in the profile AssetAdministrationShellRepositoryServiceSpecification/SSP-001
-|AssetAdministrationShellRepository +
-ServiceSpecification/SSP-003 |Query operations
+|<<asset-administration-shell-repository-service-specification-service-specification-ssp-001,AssetAdministrationShellRepositoryServiceSpecification/SSP-001>> |Full feature set
+|<<asset-administration-shell-repository-service-specification-service-specification-ssp-002,AssetAdministrationShellRepositoryServiceSpecification/SSP-002>> |Only read operations; is included in the profile AssetAdministrationShellRepositoryServiceSpecification/SSP-001
+|<<asset-administration-shell-repository-service-specification-service-specification-ssp-003,AssetAdministrationShellRepositoryServiceSpecification/SSP-003>> |Query operations
 |===
 
+[#asset-administration-shell-repository-service-specification-service-specification-ssp-001]
 === Asset Administration Shell Repository Service Specification – Full Profile
 
 [%autowidth,width="100%",cols="30%,70%",options="header",]
@@ -1033,15 +1047,17 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpecification/V3.1.0_SSP-005
 
+[#concept-description-repository-service-specification-service-specification]
 == Concept Description Repository Service Specification
 
 [cols="59%,41%"]
 |===
 h|Service Specification / Profiles h|Description
-|ConceptDescriptionRepositoryServiceSpecification/SSP-001 |Full feature set
-|ConceptDescriptionRepositoryServiceSpecification/SSP-002 |Query operations
+|<<concept-description-repository-service-specification-service-specification-ssp-001ConceptDescriptionRepositoryServiceSpecification/SSP-001>> |Full feature set
+|<<concept-description-repository-service-specification-service-specification-ssp-002,ConceptDescriptionRepositoryServiceSpecification/SSP-002>> |Query operations
 |===
 
+[#concept-description-repository-service-specification-service-specification-ssp-001]
 === Concept Description Repository Service Specification – Full Profile
 
 [%autowidth,width="100%",cols="30%,70%",options="header",]
@@ -1073,6 +1089,7 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/ConceptDescriptionRepositoryServiceSpecification/V3.1.0_SSP-001
 
+[#concept-description-repository-service-specification-service-specification-ssp-002]
 === Concept Description Repository Service Specification – Query Profile
 
 [%autowidth, width="100%", cols="30%,70%",options="header",]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -966,11 +966,11 @@ SubmodelServiceSpecification/SSP-002 as SubmodelServiceSpecification/SSP-001 or 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
 |===
 h|Name: h|Submodel Repository Template Read Profile
-h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/SubmodelServiceSpecification/SSP-004`
+h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/SubmodelRepositoryServiceSpecification/SSP-004`
 h|Feature h|Appearance
 |API and API Operations a|
-__Submodel Repository API: +
-__GetAllSubmodels +
+__Submodel Repository API:__ +
+GetAllSubmodels +
 GetSubmodelById +
 GetAllSubmodelsBySemanticId +
 GetAllSubmodelsByIdShort
@@ -981,7 +981,7 @@ GetAllSubmodelElements +
 GetSubmodelElementByPath +
 GetFileByPath
 
-_Serialization API:_ +
+__Serialization API:__ +
 GenerateSerializationByIds
 
 _Description API:_ +

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -817,7 +817,7 @@ h|Service Specification / Profiles h|Description
 [%autowidth,width="100%",cols="36%,64%",options="header",]
 |===
 h|Name: h|Submodel Repository Full Profile
-h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/SubmodelServiceSpecification/SSP-001`
+h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/SubmodelRepositoryServiceSpecification/SSP-001`
 h|Feature h|Appearance
 |API and API Operations a|
 __Submodel Repository API: +
@@ -928,7 +928,7 @@ Note 2: future versions may introduce a Submodel Repository Instance Profile.
 [%autowidth,width="100%",cols="36%,64%",options="header",]
 |===
 h|Name: h|Submodel Repository Template Profile
-h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/SubmodelServiceSpecification/SSP-003`
+h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/SubmodelRepositoryServiceSpecification/SSP-003`
 h|Feature h|Appearance
 |API and API Operations a|
 __Submodel Repository API: +

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -92,7 +92,7 @@ h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/0/AssetAdministrationS
 h|Feature h|Appearance
 |APIs and API Operations a|
 _Asset Administration Shell API:_ +
-GetAssetAdministrationShell +
+xref:specification/interfaces.adoc#GetAssetAdministrationShell[GetAssetAdministrationShell]  +
 PutAssetAdministrationShell +
 GetAllSubmodelReferences +
 PostSubmodelReference +
@@ -122,8 +122,8 @@ InvokeOperationAsync +
 GetOperationAsyncStatus +
 GetOperationAsyncResult
 
-_Serialization API:_[.underline]# +
-#GenerateSerializationByIds
+_Serialization API:_ +
+GenerateSerializationByIds
 
 _Description API:_ +
 xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
@@ -153,7 +153,7 @@ h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/1/AssetAdministrationS
 h|Feature h|Appearance
 |API Operations a|
 _Asset Administration Shell API:_ +
-GetAssetAdministrationShell +
+xref:specification/interfaces.adoc#GetAssetAdministrationShell[GetAssetAdministrationShell] +
 GetAllSubmodelReferences +
 GetAssetInformation +
 GetThumbnail
@@ -663,7 +663,7 @@ PutAssetAdministrationShellById +
 DeleteAssetAdministrationShellById
 
 _AAS API by superpath:_ +
-GetAssetAdministrationShell +
+xref:specification/interfaces.adoc#GetAssetAdministrationShell[GetAssetAdministrationShell] +
 PutAssetAdministrationShell +
 GetAllSubmodelReferences +
 PostSubmodelReference +
@@ -738,7 +738,7 @@ GetAllAssetAdministrationShellsByAssetId +
 GetAllAssetAdministrationShellsByIdShort
 
 _AAS API by superpath:_ +
-GetAssetAdministrationShell +
+xref:specification/interfaces.adoc#GetAssetAdministrationShell[GetAssetAdministrationShell] +
 GetAllSubmodelReferences +
 GetAssetInformation +
 GetThumbnail

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -660,8 +660,8 @@ GetThumbnail +
 PutThumbnail +
 DeleteThumbnail
 
-__Submodel Repository API by superpath: +
-__GetAllSubmodels +
+__Submodel Repository API by superpath:__ +
+GetAllSubmodels +
 GetSubmodelById +
 GetAllSubmodelsBySemanticId +
 GetAllSubmodelsByIdShort +
@@ -707,6 +707,8 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRepositoryServiceSpecification/V3.1.0_SSP-001
 
+
+[[asset-administration-shell-repository-service-specification-ssp-002]]
 === Asset Administration Shell Repository Service Specification – Read Profile
 
 [%autowidth,width="100%",cols="30%,70%",options="header",]
@@ -727,8 +729,8 @@ GetAllSubmodelReferences +
 GetAssetInformation +
 GetThumbnail
 
-__Submodel Repository API by superpath: +
-__GetAllSubmodels +
+__Submodel Repository API by superpath:__ +
+GetAllSubmodels +
 GetSubmodelById +
 GetAllSubmodelsBySemanticId +
 GetAllSubmodelsByIdShort
@@ -758,6 +760,8 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRepositoryServiceSpecification/V3.1.0_SSP-002
 
+
+[[asset-administration-shell-repository-service-specification-ssp-003]]
 === Asset Administration Shell Repository Service Specification – Query Profile
 
 [%autowidth, width="100%", cols="30%,70%",options="header",]
@@ -779,18 +783,21 @@ xref:specification/interfaces.adoc#GetSelfDescription[GetDescription]
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/AssetAdministrationShellRepositoryServiceSpecification/V3.1.0_SSP-003
 
+
+[[submodel-repository-service-specification]]
 == Submodel Repository Service Specification
 
 [cols="41%,59%"]
 |===
 h|Service Specification / Profiles h|Description
-|SubmodelRepositoryServiceSpecification/SSP-001 |Full feature set
-|SubmodelRepositoryServiceSpecification/SSP-002 |Only read operations; is included in the profile SubmodelRepositoryServiceSpecification/SSP-001
-|SubmodelRepositoryServiceSpecification/SSP-003 |Profile for a Submodel Repository which only contains Submodels with kind=Template; is _not_ included in the profile SubmodelRepositoryServiceSpecification/SSP-001 or the profile SubmodelRepositoryServiceSpecification/SSP-002
-|SubmodelRepositoryServiceSpecification/SSP-004 |Only read operations for a Submodel Repository which only contains Submodels with kind=Template; is included in the profile SubmodelRepositoryServiceSpecification/SSP-003 but _not_ in the profile SubmodelRepositoryServiceSpecification/SSP-001 or the profile SubmodelRepositoryService Specification/SSP-002
-|SubmodelRepositoryServiceSpecification/SSP-005 |Query operations
+|<<submodel-repository-service-specification-ssp-001,SubmodelRepositoryServiceSpecification/SSP-001>> |Full feature set
+|<<submodel-repository-service-specification-ssp-002,SubmodelRepositoryServiceSpecification/SSP-002>> |Only read operations; is included in the profile SubmodelRepositoryServiceSpecification/SSP-001
+|<<submodel-repository-service-specification-ssp-003,SubmodelRepositoryServiceSpecification/SSP-003>> |Profile for a Submodel Repository which only contains Submodels with kind=Template; is _not_ included in the profile SubmodelRepositoryServiceSpecification/SSP-001 or the profile SubmodelRepositoryServiceSpecification/SSP-002
+|<<submodel-repository-service-specification-ssp-004,SubmodelRepositoryServiceSpecification/SSP-004>> |Only read operations for a Submodel Repository which only contains Submodels with kind=Template; is included in the profile SubmodelRepositoryServiceSpecification/SSP-003 but _not_ in the profile SubmodelRepositoryServiceSpecification/SSP-001 or the profile SubmodelRepositoryService Specification/SSP-002
+|<<submodel-repository-service-specification-ssp-005,SubmodelRepositoryServiceSpecification/SSP-005>>|Query operations
 |===
 
+[[submodel-repository-service-specification-ssp-001]]
 === Submodel Repository - Full Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -847,6 +854,7 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpecification/V3.1.0_SSP-001
 
+[[submodel-repository-service-specification-ssp-002]]
 === Submodel Repository – Read Profile
 
 [%autowidth,width="100%",cols="36%,64%",options="header",]
@@ -886,6 +894,7 @@ Extent: WithBLOBValue, WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpecification/V3.1.0_SSP-002
 
+[[submodel-repository-service-specification-ssp-003]]
 === Submodel Repository - Template Profile
 
 The Submodel Repository service specification that only provides and manages Submodel Templates is represented through the profile identifier *SubmodelRepositoryServiceSpecification/SSP-003*.
@@ -952,6 +961,8 @@ Extent: WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpecification/V3.1.0_SSP-003
 
+
+[[submodel-repository-service-specification-ssp-004]]
 === Submodel Repository - Template Read Profile
 
 The Submodel Repository service specification that only provides Submodel Templates is represented through the profile identifier *SubmodelRepositoryServiceSpecification/SSP-004*.
@@ -1000,7 +1011,7 @@ Extent: WithoutBLOBValue
 
 See: https://app.swaggerhub.com/apis/Plattform_i40/SubmodelRepositoryServiceSpecification/V3.1.0_SSP-004
 
-
+[[submodel-repository-service-specification-ssp-005]]
 === Submodel Repository Service Specification – Query Profile
 
 [%autowidth, width="100%", cols="30%,70%",options="header",]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/includes/constraints.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/includes/constraints.adoc
@@ -10,12 +10,12 @@ SPDX-License-Identifier: CC-BY-4.0
 // Constraints
 
 
-:aasa001: pass:q[[underline]#Constraint AASa-001:# The value of the cursor query parameter must not be empty. If the client does not know the cursor value, it must omit the whole query parameter in the request.]
+:aasa001: pass:q[[underline]#Constraint AASa-001:# The value of the xref:http-rest-api/http-rest-api.adoc#pagination[cursor] query parameter must not be empty. If the client does not know the cursor value, it must omit the whole query parameter in the request.]
 
-:aasa002: pass:q[[underline]#Constraint AASa-002#: The base64url-encoded identifier of the semanticId shall have a length of maximum 3072 characters.]
+:aasa002: pass:q[[underline]#Constraint AASa-002#: The base64url-encoded identifier of the link: https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#has-semantics-attributes[_semanticId_] shall have a length of maximum 3072 characters.]
 
-:aasa003: pass:q[[underline]#Constraint AASa-003#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#submodel-service-specification-SSP-003[SubmodelServiceSpecification/SSP-003] must not accept or provide any Submodel with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].
+:aasa003: pass:q[[underline]#Constraint AASa-003#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#submodel-service-specification-SSP-003[SubmodelServiceSpecification/SSP-003] must not accept or provide any _Submodel_ with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].
 
-:aasa004: pass:q[[underline]#Constraint AASa-004#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#_submodel_repository_template_read_profile[SubmodelRepositoryServiceSpecification/SSP-004] must not accept or provide any Submodel with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].]
+:aasa004: pass:q[[underline]#Constraint AASa-004#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#_submodel_repository_template_read_profile[SubmodelRepositoryServiceSpecification/SSP-004] must not accept or provide any _Submodel_ with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].]
 
-:aasa005: pass:q[[underline]#Constraint AASa-005:# Only the _SubmodelElements_ root delaration can be followed with _IdShortPaths_.]
+:aasa005: pass:q[[underline]#Constraint AASa-005:# Only the _SubmodelElements_ root delaration can be followed with link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/mappings/mappings.html#_format_path_idshortpath_serialization_in_json[_IdShortPaths_].]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/includes/constraints.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/includes/constraints.adoc
@@ -14,7 +14,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 :aasa002: pass:q[[underline]#Constraint AASa-002#: The base64url-encoded identifier of the link: https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#has-semantics-attributes[_semanticId_] shall have a length of maximum 3072 characters.]
 
-:aasa003: pass:q[[underline]#Constraint AASa-003#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#submodel-service-specification-SSP-003[SubmodelServiceSpecification/SSP-003] must not accept or provide any _Submodel_ with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].
+:aasa003: pass:q[[underline]#Constraint AASa-003#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#submodel-repositoryservice-specification-SSP-003[SubmodelRepositoryServiceSpecification/SSP-003] must not accept or provide any _Submodel_ with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].
 
 :aasa004: pass:q[[underline]#Constraint AASa-004#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#_submodel_repository_template_read_profile[SubmodelRepositoryServiceSpecification/SSP-004] must not accept or provide any _Submodel_ with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].]
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/includes/constraints.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/includes/constraints.adoc
@@ -14,8 +14,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 :aasa002: pass:q[[underline]#Constraint AASa-002#: The base64url-encoded identifier of the semanticId shall have a length of maximum 3072 characters.]
 
-:aasa003: pass:q[[underline]#Constraint AASa-003#: A service implementing the SubmodelServiceSpecification/SSP-003 must not accept or provide any Submodel with the attribute “kind=Instance”.]
+:aasa003: pass:q[[underline]#Constraint AASa-003#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#submodel-service-specification-SSP-003[SubmodelServiceSpecification/SSP-003] must not accept or provide any Submodel with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].
 
-:aasa004: pass:q[[underline]#Constraint AASa-004#: A service implementing the SubmodelServiceSpecification/SSP-004 must not accept or provide any Submodel with the attribute “kind=Instance”.]
+:aasa004: pass:q[[underline]#Constraint AASa-004#: A service implementing the link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/http-rest-api/service-specifications-and-profiles.html#_submodel_repository_template_read_profile[SubmodelRepositoryServiceSpecification/SSP-004] must not accept or provide any Submodel with the attribute link:https://admin-shell-io.github.io/aas-specs-antora/IDTA-01001/v3.1/spec-metamodel/common.html#ModellingKind[kind="Instance"].]
 
 :aasa005: pass:q[[underline]#Constraint AASa-005:# Only the _SubmodelElements_ root delaration can be followed with _IdShortPaths_.]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/preamble.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/preamble.adoc
@@ -38,8 +38,6 @@ Following Clauses define the API specification for HTTP/REST:
 
 ** xref:http-rest-api/interactions.adoc[Interactions]
 
-** xref:http-rest-api/security.adoc[Security]
-
 ** xref:http-rest-api/api-code-generation.adoc[API Code Generation]
 
 xref:summary-and-outlook.adoc[] provides a summary and outlook.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-operation-parameters.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces-operation-parameters.adoc
@@ -32,7 +32,7 @@ When combined, these enumerations influence the input or response content of the
 Note: values remain unchanged with content=metadata.
 ====
 
-
+[[enumeration-level]]
 === Enumeration: Level
 
 The first enumeration _Level_ indicates the depth of the structure of the response or input content.
@@ -53,7 +53,7 @@ By this, a client can iterate the hierarchy step by step.
 Note: level parameters are mapped to the query parameter "?level" in the HTTP/REST APIs, see also xref:http-rest-api/http-rest-api.adoc#modifier-constraints[Modifier Constraints].
 ====
 
-
+[[enumeration-content]]
 === Enumeration: Content
 
 The second enumeration _Content_ indicates the kind of serialization of the response or input content.
@@ -85,7 +85,7 @@ e|Path a|Returns the idShort of the requested element and a list of _idShort_ pa
 Note: level parameters are mapped to path suffixes "/$<content>" in the HTTP/REST APIs, see also xref:http-rest-api/http-rest-api.adoc#modifier-constraints[Modifier Constraints].
 ====
 
-
+[[enumeration-extent]]
 === Enumeration: Extent
 
 The third enumeration _Extent_ indicates to which extent the response or input content is being serialized.


### PR DESCRIPTION
- BUGFIX: [Constraint AASa-004 and AASa-003](https://admin-shell-io.github.io/aas-specs-antora/IDTA-01002/v3.1/annex/overview-constraints.html) refers to submodel repository API, not to submodel API.
- BUFIX: profile identifier for submodel repsoitory
- remove link to removed security chapter
- add links