### PR TITLE
Fix AASQL grammar bugs #433, #434, #435

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
@@ -69,10 +69,10 @@ The content and structure of the AAS Query Language is defined in the context-fr
 
 This is the combined grammar for the AAS Query Language and the AAS Access Rules defined by the AAS Security specification xref:bibliography.adoc#bib3[[3\]].
 
-
-include::./grammar.adoc[]
-
-
+[source,bnf,linenums]
+----
+include::partial$bnf/grammar.bnf[]
+----
 
 == Select Expression
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
@@ -234,7 +234,7 @@ The following example is used to illustrate the comparisons. The following Asset
                 }
             ]
         }
-    ],
+    ]
 }
 ----
 

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
@@ -200,14 +200,14 @@
 <FieldIdentifierSM> ::= "$sm#" ( <SemanticIdClause> | "idShort" | "id" )
 <FieldIdentifierSME> ::= "$sme" ( "." <idShortPath> )? "#" ( <SemanticIdClause> | "idShort" | "value" | "valueType" | "language" )
 <FieldIdentifierCD> ::= "$cd#" ( "idShort" | "id" ) <ws>
-<FieldIdentifierAasDescriptor> ::= "$aasdesc#" ( "idShort" | "id" | "assetKind" | "assetType" | "globalAssetId" | <SpecificAssetIdsClause>  | "endpoints" ( "[" ( [0-9]* ) "]" )? "." <EndpointClause> | "submodelDescriptors" ( "[" ( [0-9]* ) "]" )? "." <SmDescriptorClause> )
+<FieldIdentifierAasDescriptor> ::= "$aasdesc#" ( "idShort" | "id" | "assetKind" | "assetType" | "globalAssetId" | <SpecificAssetIdsClause>  | "endpoints" ( "[" ( [0-9]* ) "]" ) "." <EndpointClause> | "submodelDescriptors" ( "[" ( [0-9]* ) "]" ) "." <SmDescriptorClause> )
 <FieldIdentifierSmDescriptor> ::= "$smdesc#" <SmDescriptorClause>
-<SmDescriptorClause> ::= ( <SemanticIdClause> | "idShort" | "id" | "endpoints" ( "[" ( [0-9]* ) "]" )? "." <EndpointClause> )
+<SmDescriptorClause> ::= ( <SemanticIdClause> | "idShort" | "id" | "endpoints" ( "[" ( [0-9]* ) "]" ) "." <EndpointClause> )
 <EndpointClause> ::= "interface" | "protocolinformation.href" 
  
-<ReferenceClause> ::= ( "type" | "keys" ( "[" ( [0-9]* ) "]" )? ( ".type" | ".value" ) )
+<ReferenceClause> ::= ( "type" | "keys" ( "[" ( [0-9]* ) "]" ) ( ".type" | ".value" ) )
 <SemanticIdClause> ::= ( "semanticId" | "semanticId." <ReferenceClause> )
-<SpecificAssetIdsClause> ::=  ( "specificAssetIds" ( "[" ( [0-9]* ) "]" )? ( ".name" | ".value" | ".externalSubjectId" | ".externalSubjectId." <ReferenceClause> ) )
+<SpecificAssetIdsClause> ::=  ( "specificAssetIds" ( "[" ( [0-9]* ) "]" ) ( ".name" | ".value" | ".externalSubjectId" | ".externalSubjectId." <ReferenceClause> ) )
 <idShortPath> ::= ( <idShort> ("[" ( [0-9]* ) "]" )? ( "." <idShortPath> )* )
 <idShort> ::= ( ( [a-z] | [A-Z] ) ( [a-z] | [A-Z] | [0-9] | "_" )* )
  

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
@@ -24,9 +24,7 @@
  
 <stringComparison> ::= 
     ( ( "$starts-with" | "$ends-with" | "$contains" | "$regex") <ws> "(" <ws> <stringOperand> <ws> "," <ws> <stringOperand> <ws> ")" <ws> ) |
-    ( <stringOperand> <ws> <allComparisons> <ws> <stringOperand> <ws> ) |
-    ( <stringOperand> <ws> <allComparisons> <ws> <FieldIdentifierString> <ws> ) |
-    ( <FieldIdentifierString> <ws> <allComparisons> <ws> <stringOperand> <ws> )
+    ( <stringOperand> <ws> <allComparisons> <ws> <stringOperand> <ws> )
 
 <numericalComparison> ::= 
     ( <numericalOperand> <ws> <allComparisons> <ws> <numericalOperand> <ws> ) |

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
@@ -1,4 +1,3 @@
-....
 <grammar> ::= <query> | <AllAccessPermissionRules>
  
 <query> ::= <selectStatement>? <logicalExpression>
@@ -213,4 +212,3 @@
 <idShort> ::= ( ( [a-z] | [A-Z] ) ( [a-z] | [A-Z] | [0-9] | "_" )* )
  
 <ws> ::= ( " " | "\t" | "\r" | "\n" )*
-....

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
@@ -25,6 +25,8 @@
 <stringComparison> ::= 
     ( ( "$starts-with" | "$ends-with" | "$contains" | "$regex") <ws> "(" <ws> <stringOperand> <ws> "," <ws> <stringOperand> <ws> ")" <ws> ) |
     ( <stringOperand> <ws> <allComparisons> <ws> <stringOperand> <ws> )
+    ( <stringOperand> <ws> <allComparisons> <ws> <FieldIdentifierString> <ws> ) |
+    ( <FieldIdentifierString> <ws> <allComparisons> <ws> <stringOperand> <ws> )
 
 <numericalComparison> ::= 
     ( <numericalOperand> <ws> <allComparisons> <ws> <numericalOperand> <ws> ) |

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
@@ -23,7 +23,7 @@
 <allComparisons> ::= ( "$eq" | "$ne" | "$gt" | "$lt" | "$ge" | "$le" )
  
 <stringComparison> ::= 
-    ( ( "$starts-with" | "ends-with" | "$contains" | "$regex") <ws> "(" <ws> <stringOperand> <ws> "," <ws> <stringOperand> <ws> ")" <ws> ) |
+    ( ( "$starts-with" | "$ends-with" | "$contains" | "$regex") <ws> "(" <ws> <stringOperand> <ws> "," <ws> <stringOperand> <ws> ")" <ws> ) |
     ( <stringOperand> <ws> <allComparisons> <ws> <stringOperand> <ws> ) |
     ( <stringOperand> <ws> <allComparisons> <ws> <FieldIdentifierString> <ws> ) |
     ( <FieldIdentifierString> <ws> <allComparisons> <ws> <stringOperand> <ws> )


### PR DESCRIPTION
This PR fixes bugs #433 , #434 , #435 

It also refactors the `grammar.adoc` file. The file contained a BNF grammar for AASQL.
I have placed the grammar in a `.bnf` file in `partials` as it is done in the `aas-specs-security` repo.