### PR TITLE
Added missing 404 return code to /shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}

### DIFF
--- a/AssetAdministrationShellRegistryServiceSpecification/V3.1_SSP-001.yaml
+++ b/AssetAdministrationShellRegistryServiceSpecification/V3.1_SSP-001.yaml
@@ -316,6 +316,8 @@ paths:
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/responses/bad-request'
         '403':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/responses/forbidden'
+        '404':
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/responses/not-found'
         '500':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/responses/internal-server-error'    
         default:


### PR DESCRIPTION
As discussed, added missing 404 for "/shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}" that was contained in entire-api-collection.