### PR TITLE
fix(bnf,schema): harmonize SecurityQueryFilter and add FILTERLIST

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
@@ -12,6 +12,10 @@
       "type": "string",
        "pattern": "^(?:\\$aas#(?:idShort|id|assetInformation\\.assetKind|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|submodels\\[[0-9]*\\]\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))|\\$sm#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|value|valueType|language)|\\$cd#(?:idShort|id)|\\$aasdesc#(?:idShort|id|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)|submodelDescriptors\\[[0-9]*\\]\\.(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))|\\$smdesc#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))$"
     },
+    "FragmentFieldIdentifier": {
+      "type": "string",
+      "pattern": "^(?:\\$aas#(?:idShort|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|submodels\\[[0-9]*\\](?:\\.keys\\[[0-9]*\\])?)|\\$sm#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?(?:#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|value|valueType|language))?|\\$cd#idShort|\\$aasdesc#(?:idShort|description|displayName|extension|administration|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|endpoints\\[[0-9]*\\]|submodelDescriptors\\[[0-9]*\\](?:\\.(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))?)|\\$smdesc#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))$"
+    },
     "hexLiteralPattern": {
       "type": "string",
       "pattern": "^16#[0-9A-F]+$"
@@ -653,6 +657,12 @@
         "FILTER": {
           "$ref": "#/definitions/SecurityQueryFilter",
           "additionalProperties": false
+        },
+        "FILTERLIST": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityQueryFilter"
+          }
         }
       },
       "allOf": [
@@ -705,7 +715,7 @@
       "type": "object",
       "properties": {
         "FRAGMENT": {
-          "type": "string"
+          "$ref": "#/definitions/FragmentFieldIdentifier"
         },
         "CONDITION": {
           "$ref": "#/definitions/logicalExpression"

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
@@ -93,17 +93,18 @@
     ( "DEFFORMULAS" <ws> <StringLiteral> <ws> <logicalExpression> <ws> )* 
     ( <AccessPermissionRule> <ws> )*
  
-<AccessPermissionRule> ::= 
+<AccessPermissionRule> ::=
     "ACCESSRULE:" <ws>
-    ( <ACL> | <UseACL> ) <ws> 
-    "OBJECTS:" <ws> 
-    ( <SingleObject> <ws> )* 
-    ( <UseObjectGroup> <ws> )* 
+    ( <ACL> | <UseACL> ) <ws>
+    "OBJECTS:" <ws>
+    ( <SingleObject> <ws> )*
+    ( <UseObjectGroup> <ws> )*
     ( ( "FORMULA:" <ws> <logicalExpression> <ws> ) | ( <UseFormula> <ws> ) )
     ( "FILTER:" <ws> <SecurityQueryFilter> )?
+    ( "FILTERLIST:" <ws> ( <SecurityQueryFilter> <ws> )* )?
 
 <SecurityQueryFilter> ::=
-    <FragmentObject> <ws>
+    ( "FRAGMENT:" <ws> <FieldIdentifierFragment> <ws> )
     ( ( "CONDITION:" <ws> <logicalExpression> <ws> ) | ( <UseFormula> <ws> ) )
 
 <ACL> ::= 
@@ -211,5 +212,20 @@
 <SpecificAssetIdsClause> ::=  ( "specificAssetIds" ( "[" ( [0-9]* ) "]" ) ( ".name" | ".value" | ".externalSubjectId" | ".externalSubjectId." <ReferenceClause> ) )
 <idShortPath> ::= ( <idShort> ("[" ( [0-9]* ) "]" )* ( "." <idShortPath> )* )
 <idShort> ::= ( ( [a-z] | [A-Z] ) (( [a-z] | [A-Z] | [0-9] | "_"   | "-" )* ( [a-z] | [A-Z] | [0-9] | "_" ) )? )
+
+<FieldIdentifierFragment> ::= <FieldIdentifierAASFragment> | <FieldIdentifierSMFragment> | <FieldIdentifierSMEFragment> | <FieldIdentifierCDFragment> | <FieldIdentifierAasDescriptorFragment> | <FieldIdentifierSmDescriptorFragment>
+
+<FieldIdentifierAASFragment> ::= "$aas#" ( "idShort" | "assetInformation.assetType" | "assetInformation.globalAssetId" | "assetInformation." <SpecificAssetIdsClauseFragment> | "submodels" ( "[" ( [0-9]* ) "]" ) ("." <ReferenceClauseFragment>)? )
+<FieldIdentifierSMFragment> ::= "$sm#" ( <SemanticIdClauseFragment> | "idShort" | "id" )
+<FieldIdentifierSMEFragment> ::= "$sme" ( "." <idShortPath> )? ( "#" ( <SemanticIdClauseFragment> | "idShort" | "value" | "valueType" | "language" ))?
+<FieldIdentifierCDFragment> ::= "$cd#" ( "idShort" ) <ws>
+<FieldIdentifierAasDescriptorFragment> ::= "$aasdesc#" ( "idShort" | "description" | "displayName" | "extension" | "administration" | "assetKind" | "assetType" | "globalAssetId" | <SpecificAssetIdsClauseFragment> | <EndpointClauseFragment> |  "submodelDescriptors[" ( [0-9]* ) "]" ("." <SmDescriptorClauseFragment>)? )
+<FieldIdentifierSmDescriptorFragment> ::= "$smdesc#" <SmDescriptorClauseFragment>
+
+<SpecificAssetIdsClauseFragment> ::= "specificAssetIds" ( "[" ( [0-9]* ) "]" ) (".externalSubjectId" | ".externalSubjectId." <ReferenceClauseFragment>)?
+<SmDescriptorClauseFragment> ::= ( <SemanticIdClauseFragment> | "idShort" | <EndpointClauseFragment> )
+<EndpointClauseFragment> ::= "endpoints" ( "[" ( [0-9]* ) "]" )
+<ReferenceClauseFragment> ::= ( "keys" ( "[" ( [0-9]* ) "]" ) )
+<SemanticIdClauseFragment> ::= ( "semanticId" | "semanticId." <ReferenceClauseFragment> )
 
 <ws> ::= ( " " | "\t" | "\r" | "\n" )*

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
@@ -12,6 +12,10 @@
       "type": "string",
       "pattern": "^(?:\\$aas#(?:idShort|id|assetInformation\\.assetKind|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|submodels\\[[0-9]*\\]\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))|\\$sm#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|value|valueType|language)|\\$cd#(?:idShort|id)|\\$aasdesc#(?:idShort|id|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)|submodelDescriptors\\[[0-9]*\\]\\.(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))|\\$smdesc#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))$"
     },
+    "FragmentFieldIdentifier": {
+      "type": "string",
+      "pattern": "^(?:\\$aas#(?:idShort|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|submodels\\[[0-9]*\\](?:\\.keys\\[[0-9]*\\])?)|\\$sm#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?(?:#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|value|valueType|language))?|\\$cd#idShort|\\$aasdesc#(?:idShort|description|displayName|extension|administration|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|endpoints\\[[0-9]*\\]|submodelDescriptors\\[[0-9]*\\](?:\\.(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))?)|\\$smdesc#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))$"
+    },
     "hexLiteralPattern": {
       "type": "string",
       "pattern": "^16#[0-9A-F]+$"
@@ -637,6 +641,12 @@
         "FILTER": {
           "$ref": "#/definitions/SecurityQueryFilter",
           "additionalProperties": false
+        },
+        "FILTERLIST": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityQueryFilter"
+          }
         }
       },
       "allOf": [
@@ -689,7 +699,7 @@
       "type": "object",
       "properties": {
         "FRAGMENT": {
-          "type": "string"
+          "$ref": "#/definitions/FragmentFieldIdentifier"
         },
         "CONDITION": {
           "$ref": "#/definitions/logicalExpression"


### PR DESCRIPTION
## Summary

Harmonizes `SecurityQueryFilter` between `aas-specs-api` and
`aas-specs-security`, and adds the missing `FILTERLIST` construct to
the API grammar and JSON schemas. Pairs with the review-finding T-02
"incompatible FILTER definitions".

## Problem

- The API BNF defined `<SecurityQueryFilter>` over `<FragmentObject>`
  (i.e. `"FRAGMENT" <RouteLiteral>`), while the Security BNF uses
  `"FRAGMENT:" <FieldIdentifierFragment>`. These are syntactically
  distinct and describe different things.
- The API `AccessPermissionRule` had no `FILTERLIST`, whereas the
  Security spec has used `FILTERLIST` for some time.
- The API JSON Schema typed `SecurityQueryFilter.FRAGMENT` as a plain
  `string`, losing all validation semantics of a field identifier.

Consequence: Implementers cannot reuse one parser/validator for both
specs; rules valid under the security spec are not valid under the
API spec and vice versa.

## Solution

The Security spec is taken as the canonical form.

**BNF (`partials/bnf/grammar.bnf`):**

- `<SecurityQueryFilter>` is rewritten to
  `"FRAGMENT:" <ws> <FieldIdentifierFragment>`.
- `<AccessPermissionRule>` gains the optional
  `"FILTERLIST:" ( <SecurityQueryFilter> )*` block (sibling of
  `FILTER`).
- The `<FieldIdentifierFragment>` family (AAS, SM, SME, CD, AAS
  Descriptor, SM Descriptor) and its supporting `*Fragment` clauses
  (`SpecificAssetIds`, `SemanticId`, `Reference`, `Endpoint`,
  `SmDescriptor`) are ported from `aas-specs-security`.

**JSON Schema (`partials/query-json-schema.json` and
`pages/schema.adoc`):**

- New `FragmentFieldIdentifier` definition (regex sibling of
  `modelStringPattern`, restricted to fragment-legal fields).
- `SecurityQueryFilter.FRAGMENT` becomes `$ref:
  "#/definitions/FragmentFieldIdentifier"`.
- `AccessPermissionRule.properties.FILTERLIST` added (array of
  `SecurityQueryFilter`).

## Impact

- Affected specs: IDTA-01002 (API), indirectly IDTA-01004 (Security,
  no change here; this PR aligns API to Security).
- Rules containing `FILTER: FRAGMENT "..."` (literal route form) were
  never interoperable and are now explicitly invalid — recommended
  migration: `FILTER: FRAGMENT: $sme("...").path#idShort`.
- Rules currently valid on Security become valid on API as well.
- Follow-up PR 1 will deduplicate these definitions into a shared
  partial (single source of truth).

## Review notes

- Please confirm the port of `<FieldIdentifierFragment>` productions
  is byte-identical to `aas-specs-security/partials/bnf/access-rules.bnf`
  lines 224–235.
- `FragmentFieldIdentifier` regex is identical to the one in
  `aas-specs-security/partials/json/aas-queries-and-access-rules-schema.json`
  line 17.
- Prose updates documenting `FILTERLIST` and the new `FILTER`
  fragment syntax are intentionally left for PR 11 to keep the diff
  focused.

## Related

Review Finding **T-02**: SecurityQueryFilter / FILTERLIST mismatch.
Depends on: T-04 (`aas-specs-security` PR #71) for schema validity.
