### PR TITLE
fix(schema): use anyOf where BNF allows mixed inline and named groups

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
@@ -607,7 +607,7 @@
         "RIGHTS",
         "ACCESS"
       ],
-      "oneOf": [
+      "anyOf": [
         {
           "required": [
             "ATTRIBUTES"
@@ -671,7 +671,7 @@
           ]
         },
         {
-          "oneOf": [
+          "anyOf": [
             {
               "required": [
                 "OBJECTS"

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
@@ -591,7 +591,7 @@
         "RIGHTS",
         "ACCESS"
       ],
-      "oneOf": [
+      "anyOf": [
         {
           "required": [
             "ATTRIBUTES"
@@ -655,7 +655,7 @@
           ]
         },
         {
-          "oneOf": [
+          "anyOf": [
             {
               "required": [
                 "OBJECTS"


### PR DESCRIPTION
## Summary

Replaces `oneOf` with `anyOf` in exactly those places where the BNF
uses concatenation (both variants may appear together) rather than
alternation (exactly one). Keeps `oneOf` where the BNF is genuinely
XOR.

## Problem

The BNF makes a deliberate distinction between "mix allowed" and
"exactly one":

```
<AttributeGroup> ::=
    ( <SingleAttribute> <ws> )*
    ( <UseAttributeGroup> <ws> )*     -- CAT (mix allowed)

<AccessPermissionRule> ::=
    ( <ACL> | <UseACL> )                -- XOR
    "OBJECTS:" <ws>
    ( <SingleObject> <ws> )*
    ( <UseObjectGroup> <ws> )*          -- CAT (inline)
    ( "FORMULA:" ... | <UseFormula> )   -- XOR
```

But the JSON Schema used `oneOf` for the CAT pairs too, making the
schema strictly more restrictive than the grammar. A rule that lists
both inline `ATTRIBUTES` and a `USEATTRIBUTES` reference was legal
per BNF and illegal per schema.

## Solution

Change `oneOf` to `anyOf` in exactly the CAT cases:

- `ACL.{ATTRIBUTES, USEATTRIBUTES}`
- `AccessPermissionRule.{OBJECTS, USEOBJECTS}`
- *aas-specs-security only*: `DEFATTRIBUTES` item
  `{attributes, USEATTRIBUTES}`

Keep `oneOf` for the XOR cases:

- `AccessPermissionRule.{ACL, USEACL}`
- `AccessPermissionRule.{FORMULA, USEFORMULA}`
- `DEFOBJECTS` item `{objects, USEOBJECTS}` (grammar
  `<ObjectGroup>` is XOR: `( A )* | ( B )*`)
- `SecurityQueryFilter.{CONDITION, USEFORMULA}`

## Impact

- Affected specs: IDTA-01002 (API) and IDTA-01004 (Security).
- Strict relaxation: every document previously valid remains valid;
  additionally, documents that combine inline and named attribute/
  object groups now validate.
- No grammar changes.

## Review notes

- Please confirm the `ObjectGroup` grammar is indeed intended as XOR
  (production line: `( <SingleObject> )* | ( <UseObjectGroup> )*`)
  while the inline `OBJECTS:` block inside `<AccessPermissionRule>`
  is intended as CAT. If both are meant to be CAT, `DEFOBJECTS`
  should also be flipped to `anyOf` — trivial follow-up.
- The single-string `USEATTRIBUTES` in ACL vs the `array-of-string`
  in `DEFATTRIBUTES` is a separate inconsistency and is not
  addressed here.

## Related

Review Finding **T-13** / `ANOS#3`: XOR vs mix semantics between BNF and JSON
Schema.
