### PR TITLE
docs(profiles): add FieldIdentifier applicability table per profile

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -76,6 +76,30 @@ Additional profiles might be introduced in future versions of this document.
 Note: in the following, only the last part (<name of service specification>/SSP-<profile number>) is used in the text for better readability, e.g. “AssetAdministrationShellServiceSpecification/SSP-001” instead of “https://admin-shell.io/aas/API/3/2/AssetAdministrationShellServiceSpecification/SSP-001”.
 ====
 
+[#fieldidentifier-applicability]
+=== FieldIdentifier Applicability per Profile
+
+The AAS Query Language (see xref:query-language.adoc[]) and the Security Access Rule Model (see the Security specification, IDTA-01004) use a set of FieldIdentifier prefixes (`$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc`, `$smdesc`). Not every prefix is meaningful in every profile, because the underlying data is only exposed by specific service specifications.
+
+The following table summarises which FieldIdentifier prefix is applicable per service specification family:
+
+[cols="3,1,1,1,1,1,1",options="header"]
+|===
+| Service Specification (family) | $aas | $sm | $sme | $cd | $aasdesc | $smdesc
+| AssetAdministrationShellRepositoryServiceSpecification | ✓ | ✓ | ✓ | — | — | —
+| SubmodelRepositoryServiceSpecification                 | — | ✓ | ✓ | — | — | —
+| ConceptDescriptionRepositoryServiceSpecification       | — | — | — | ✓ | — | —
+| AssetAdministrationShellRegistryServiceSpecification   | — | — | — | — | ✓ | ✓
+| SubmodelRegistryServiceSpecification                   | — | — | — | — | — | ✓
+| AssetAdministrationShellServiceSpecification           | ✓ | ✓ | ✓ | — | — | —
+| SubmodelServiceSpecification                           | — | ✓ | ✓ | — | — | —
+| DiscoveryServiceSpecification                          | — | — | — | — | — | —
+|===
+
+Queries and access rules that reference a prefix marked with "—" for the chosen profile are treated as *not applicable* in that profile: they MUST NOT cause a parse or evaluation error, they simply do not match any object in the deployment. Implementations SHOULD clearly indicate in their deployment documentation which profiles they expose so that operators can scope their rules accordingly.
+
+This table is referenced by IDTA-01004 § "Descriptor FieldIdentifier Applicability".
+
 [#asset-administration-shell-service-specification]
 == Asset Administration Shell Service Specification
 


### PR DESCRIPTION
## Summary

Add a normative "FieldIdentifier Applicability per Profile" section to IDTA-01002 service specifications and profiles. The section states which Query / Access-Rule FieldIdentifier prefixes (`$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc`, `$smdesc`) are meaningful in which service specification family, and how non-applicable rules MUST be handled.

## Problem

The Query Language and the Security Access Rule Model (IDTA-01004) use the same FieldIdentifier prefixes but the underlying data is only exposed by specific profiles. For example, `$aasdesc` only makes sense in Registry deployments; in a pure Repository deployment there is no descriptor data to evaluate against. The specification currently does not say what should happen when such a rule or query is formulated against a profile that cannot provide the data, and implementations disagree.

## Solution

Add a table to `service-specifications-and-profiles.adoc` listing the applicable prefixes per service specification family and specify that non-applicable rules/queries MUST be treated as "not applicable" (no match, no error).

## Affected files

- `documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc`

## Review notes

- This PR is paired with a companion PR in `aas-specs-security` (IDTA-01004) that references this section from the Descriptor applicability paragraph in the Access Rule Model.
- No BNF / schema / API operation changes.

Refs: Review Finding T-07 / `ANOS#6`
