### PR TITLE
docs(query-language): reference cross-spec terminology matrix (T-09)

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
@@ -107,6 +107,11 @@ Can start at any possible Submodel Element, is *not* restricted to Submodel Elem
 | `$smdesc` a| Starting point for fields available in Submodel Descriptors | `$smdesc#endpoints[0].protocolinformation.href`
 |===
 
+[NOTE]
+====
+The prefixes `$aas`, `$sm`, `$sme`, `$cd`, `$aasdesc` and `$smdesc` correspond directly to the AAS Metamodel classes `AssetAdministrationShell`, `Submodel`, `SubmodelElement`, `ConceptDescription`, `AssetAdministrationShellDescriptor` and `SubmodelDescriptor`, and to the API resources `/shells`, `/submodels`, `.../submodel-elements/{idShortPath}`, `/concept-descriptions`, `/shell-descriptors` and `/submodel-descriptors` respectively. The normative cross-specification mapping is given in the "Terminology Across IDTA-01001, IDTA-01002 and IDTA-01004" section of IDTA-01001 (AAS Metamodel). All prefixes are lower-case; variants such as `$aasDesc` or `$SmDesc` MUST be rejected by conforming parsers.
+====
+
 Attribute declarations point to literal values that provide the input for comparisons. It is not possible to point to objects or lists, only atomic values. Attribute declarations present a subset of the attributes defined by the AAS Metamodel and the extension classes of Clause xref:specification/interfaces-payload.adoc[Data Types for Payload].
 
 .Attribute Elements for Field Identifiers. `<index>` is an optional nonNegativeInteger value. No `<index>` shall be interpreted as 'anywhere in the list'.


### PR DESCRIPTION
## Summary

Add a NOTE next to the FieldIdentifier root-element table in the Query Language chapter that explicitly maps each `$`-prefix to the corresponding Metamodel class and API resource path, and points to the new normative cross-spec terminology matrix in IDTA-01001.

## Problem

Three specs use different surface forms for the same concept (Metamodel class name, API path segment, Query/Access-Rule prefix). The Query Language chapter defines the prefixes but does not make the mapping to the Metamodel and API explicit, which leads to small inconsistencies (e.g. `$aasDesc` vs. `$aasdesc`).

## Solution

- Add a short normative NOTE under the "Root Elements for Field Identifiers" table.
- Explicitly state that prefixes are lower-case and that variants like `$aasDesc` MUST be rejected.
- Reference the new "Terminology Across IDTA-01001, IDTA-01002 and IDTA-01004" section in IDTA-01001 (Metamodel) as the normative single source of truth.

## Affected files

- `documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc`

## Review notes

- No grammar/schema changes.
- Companion PRs: `admin-shell-io/aas-specs-metamodel` (introduces the matrix) and `admin-shell-io/aas-specs-security` (mirrors this NOTE in the Access Rule Model chapter).

Refs: Review Finding T-09 / `ANOS#9`
