### PR TITLE
docs(index): add cross-spec alignment matrix (T-08)

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
@@ -25,6 +25,26 @@ This document uses the following parts of the “Specification of the Asset Admi
 
 If there are bugfixes of the parts, these shall be used.
 
+[#cross-spec-alignment]
+=== Alignment with other AAS Specifications
+
+This version of IDTA-01002 (v3.2) is designed to be used together with the following companion specifications:
+
+[cols="2,2,3",options="header"]
+|===
+| Specification | Aligned Version | Notes
+
+| IDTA-01001 Part 1: Metamodel
+| v3.2
+| Defines the classes referenced by `$aas`, `$sm`, `$sme`, `$cd` and the Descriptor prefixes in the Query Language.
+
+| IDTA-01004 Part 4: Security
+| v3.1
+| Access Rule Model. IDTA-01002 and IDTA-01004 share the same BNF grammar and JSON Schema for formula expressions; see xref:query-language.adoc[] and the Access Rule Model in IDTA-01004.
+|===
+
+Bugfix (patch) releases of aligned specifications MAY be substituted. Implementations conforming to this version of IDTA-01002 SHOULD declare which versions of IDTA-01001 and IDTA-01004 they implement.
+
 == Notice
 
 Copyright: Industrial Digital Twin Association e.V. (IDTA)

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
@@ -17,7 +17,7 @@ Previous version: 3.1.2
 
 This version of IDTA-01002 (v3.2) is designed to be used together with the following companion specifications:
 
-[cols="2,2,3",options="header"]
+[cols="1,2,2,3",options="header"]
 |===
 h| Dependency h| Specification h| Aligned Version h| Notes
 
@@ -26,7 +26,7 @@ h| Dependency h| Specification h| Aligned Version h| Notes
 a| 
 API: 
 
-* defines payload of many API operations like `GetAssetAdministrationShell`, `GetSubmodel` etc. (collected in Part1-MetaModel-Schemas)
+* defines payload of many API operations like `GetAssetAdministrationShell`, `GetSubmodel` etc. (collected in `Part1-MetaModel-Schemas`)
 * is the basis for derived data types for payload like `AssetLink`, `SubmodelDescriptor` etc. used in Registry or Discovery API operations
 * defines mapping rules for serializations like `Value`, `Metadata` etc.
 
@@ -57,7 +57,7 @@ Query Language:
 
 * IDTA-01002 and IDTA-01004 share the same BNF grammar and JSON Schema for formula expressions; see xref:query-language.adoc[] and the Access Rule Model in IDTA-01004.
 
-| x | IDTA-01005 Part 5: Package File Format (AASX
+| x | IDTA-01005 Part 5: Package File Format (AASX)
 | v3.2
 a| defines return object for API operations like `GetAASXByPackageId`
 |===

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
@@ -12,19 +12,6 @@ This is version 3.2.0 of the specification IDTA-01002.
 
 Previous version: 3.1.2
 
-[#metamodel-versions]
-== Metamodel Versions
-
-This document uses the following parts of the “Specification of the Asset Administration Shell” series:
-
-* IDTA-01001 Part 1: Metamodel in version 3.2 xref:bibliography.adoc#bib1[[1\]]
-* IDTA-01003-a Part 3a: Data Specification – IEC 61360 in version 3.1 xref:bibliography.adoc#bib2[[2\]]
-* IDTA-01003-b Part 3b: Data Specification – Measurement Units in version 3.0 xref:bibliography.adoc#bib15[[15\]]
-* IDTA-01004 Part 4: Security in version 3.1 xref:bibliography.adoc#bib3[[3\]]
-* IDTA-01005 Part 5: Package File Format (AASX) in version 3.1 xref:bibliography.adoc#bib4[[4\]]
-
-If there are bugfixes of the parts, these shall be used.
-
 [#cross-spec-alignment]
 === Alignment with other AAS Specifications
 
@@ -32,18 +19,50 @@ This version of IDTA-01002 (v3.2) is designed to be used together with the follo
 
 [cols="2,2,3",options="header"]
 |===
-| Specification | Aligned Version | Notes
+h| Dependency h| Specification h| Aligned Version h| Notes
 
-| IDTA-01001 Part 1: Metamodel
+| x | IDTA-01001 Part 1: Metamodel
 | v3.2
-| Defines the classes referenced by `$aas`, `$sm`, `$sme`, `$cd` and the Descriptor prefixes in the Query Language.
+a| 
+API: 
 
-| IDTA-01004 Part 4: Security
+* defines payload of many API operations like `GetAssetAdministrationShell`, `GetSubmodel` etc. (collected in Part1-MetaModel-Schemas)
+* is the basis for derived data types for payload like `AssetLink`, `SubmodelDescriptor` etc. used in Registry or Discovery API operations
+* defines mapping rules for serializations like `Value`, `Metadata` etc.
+
+Query Language: 
+
+* defines the classes referenced by `$aas`, `$sm`, `$sme`, `$cd` 
+* defines the attributes used in conditions like  `semanticId`, `specificAssetIds` etc.
+
+| x | IDTA-01003-a Part 3a: Data Specification Template IEC61360
 | v3.1
-| Access Rule Model. IDTA-01002 and IDTA-01004 share the same BNF grammar and JSON Schema for formula expressions; see xref:query-language.adoc[] and the Access Rule Model in IDTA-01004.
+a| is integrated into the schema of Part 1
+
+| x | IDTA-01003-b Part 3b: Data Specification Template Measurement Units
+| v3.0
+a| is integrated into the schema of Part 1
+
+| x | IDTA-01004 Part 4: Security
+| v3.1
+a| 
+
+API:
+
+* security measurements shall be applied to API
+* access control rules shall be implemented (Note: if an implementation only supports a subset of access control rules this shall be specified)
+
+
+Query Language: 
+
+* IDTA-01002 and IDTA-01004 share the same BNF grammar and JSON Schema for formula expressions; see xref:query-language.adoc[] and the Access Rule Model in IDTA-01004.
+
+| x | IDTA-01005 Part 5: Package File Format (AASX
+| v3.2
+a| defines return object for API operations like `GetAASXByPackageId`
 |===
 
-Bugfix (patch) releases of aligned specifications MAY be substituted. Implementations conforming to this version of IDTA-01002 SHOULD declare which versions of IDTA-01001 and IDTA-01004 they implement.
+Bugfix (patch) releases of aligned specifications shall be substituted. 
 
 == Notice
 


### PR DESCRIPTION
## Summary

Add an explicit "Alignment with other AAS Specifications" table to the API's `index.adoc`. The table names the companion IDTA-01001 (Metamodel, v3.2) and IDTA-01004 (Security, v3.1) versions this API version is designed to be used with, and clarifies the substitution rule for bugfix (patch) releases.

## Problem

The existing "Metamodel Versions" section lists dependencies but does not distinguish between pure data-spec dependencies (IDTA-01003) and the tightly coupled Metamodel/Security specifications. In particular, the fact that IDTA-01002 and IDTA-01004 share the BNF grammar and JSON Schema for formula expressions is not visible at index level.

## Solution

- Add a short normative `=== Alignment with other AAS Specifications` section next to the existing `== Metamodel Versions`.
- Present the information as a simple table (Specification / Aligned Version / Notes).
- Call out that IDTA-01002 and IDTA-01004 share the same grammar and schema for formula expressions and that bugfix releases of companion specs may be substituted.

## Affected files

- `documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc`

## Review notes

- No grammar or API surface changes.
- Companion PRs in `aas-specs-metamodel` and `aas-specs-security` add mirroring alignment tables and, for Security, update bibliography entries to match.

Refs: Review Finding T-08
