### PR TITLE
docs(query-language): declare IDTA-01002 as SoT for formula grammar (T-01)

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
@@ -22,6 +22,15 @@ The Asset Administration Shell propagates a Query Language inspired by the so-ca
 Note: The AAS Query Language and the AAS Access Rules xref:bibliography.adoc#bib3[[3\]] share the same BNF grammar. Therefore, the result is a superset, with `query` as the entrypoint for the Query Language. 
 ====
 
+[#formula-grammar-sot]
+=== Single source of truth for the formula grammar and JSON Schema
+
+The BNF grammar and JSON Schema productions for *formula expressions* (logical expressions, comparisons, FieldIdentifiers, value literals, operands, type casts, and `$match` / `$and` / `$or` / `$not` operators) are *normatively defined in this specification* (IDTA-01002, this chapter and the JSON Schema below).
+
+IDTA-01004 Part 4: Security xref:bibliography.adoc#bib3[[3\]] uses the same formula grammar and schema for `FORMULA`, `FILTER` and related constructs in Access Rules. IDTA-01004 MUST NOT redefine or diverge from these shared productions; it only adds Access-Rule-specific productions (`ACL`, `OBJECTS`, `RIGHTS`, `ACCESS`, `ROUTE`, etc.) on top.
+
+If a future bugfix or minor release changes a shared production in IDTA-01002, IDTA-01004 inherits that change. Implementations SHOULD validate formulas against the schema shipped with their IDTA-01002 version.
+
 
 == Use Case Examples
 


### PR DESCRIPTION
## Summary

Add a normative subsection "Single source of truth for the formula grammar and JSON Schema" to the Query Language chapter. This formally names IDTA-01002 as the authoritative source for all formula productions shared with IDTA-01004 (Security / Access Rule Model).

## Problem

Today the same formula grammar (logical expressions, comparisons, FieldIdentifiers, value literals, type casts, `$match`/`$and`/`$or`/`$not`) and the same JSON Schema blocks are shipped in both `aas-specs-api` and `aas-specs-security`. The two copies are maintained in parallel, but no text states which one is authoritative. This creates recurring drift between the two specs (recent examples: `timeLiteralPattern`, `$dayOfWeek` refs, `supplementalSemanticIds`).

## Solution

- Add a new subsection `=== Single source of truth for the formula grammar and JSON Schema` right below the existing note that Query Language and Access Rules share the same BNF grammar.
- State that formula productions are normatively defined in IDTA-01002.
- State that IDTA-01004 MUST NOT redefine or diverge from these productions and only adds Access-Rule-specific productions on top.
- Clarify that bugfixes in IDTA-01002 are automatically inherited by IDTA-01004.

## Affected files

- `documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc`

## Review notes

- Pure documentation change, no normative change to the grammar or schema content.
- Companion PR in `aas-specs-security` adds the mirrored statement.

Refs: Review Finding T-01 / `ANOS#11`
