### PR TITLE
docs(index): add cross-spec alignment matrix

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/index.adoc
@@ -25,6 +25,26 @@ This document uses the following parts of the “Specification of the Asset Admi
 
 If there are bugfixes of the parts, these shall be used.
 
+[#cross-spec-alignment]
+=== Alignment with other AAS Specifications
+
+This version of IDTA-01002 (v3.2) is designed to be used together with the following companion specifications:
+
+[cols="2,2,3",options="header"]
+|===
+| Specification | Aligned Version | Notes
+
+| IDTA-01001 Part 1: Metamodel
+| v3.2
+| Defines the classes referenced by `$aas`, `$sm`, `$sme`, `$cd` and the Descriptor prefixes in the Query Language.
+
+| IDTA-01004 Part 4: Security
+| v3.1
+| Access Rule Model. IDTA-01002 and IDTA-01004 share the same BNF grammar and JSON Schema for formula expressions; see xref:query-language.adoc[] and the Access Rule Model in IDTA-01004.
+|===
+
+Bugfix (patch) releases of aligned specifications MAY be substituted. Implementations conforming to this version of IDTA-01002 SHOULD declare which versions of IDTA-01001 and IDTA-01004 they implement.
+
 == Notice
 
 Copyright: Industrial Digital Twin Association e.V. (IDTA)


### PR DESCRIPTION


Add an explicit "Alignment with other AAS Specifications" table to the Metamodel Versions section, listing the companion Metamodel (IDTA-01001 v3.2) and Security (IDTA-01004 v3.1) versions this API version is designed to be used with, plus a short note on what each companion spec contributes and the substitution rule for bugfix releases.

Refs: Review Finding T-08
Made-with: Cursor but manually edited and improved