### PR TITLE
Fix wrong profile identifier for SubmodelServiceSpecification/SSP-002

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/service-specifications-and-profiles.adoc
@@ -254,7 +254,7 @@ The submodel service specification with its minimal feature set is represented t
 [%autowidth,width="100%",cols="36%,64%",options="header",]
 |===
 h|Name: h|Submodel Read Profile
-h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/1/AssetAdministrationShellServiceSpecification/SSP-002`
+h|Profile Identifier: |`\https://admin-shell.io/aas/API/3/1/SubmodelServiceSpecification/SSP-002`
 h|Feature h|Appearance
 |API and API Operations a|
 _Submodel API:_ +


### PR DESCRIPTION
## Summary

- Fixes wrong Profile Identifier in the Submodel Read Profile (SSP-002) table at line 257
- `AssetAdministrationShellServiceSpecification/SSP-002` → `SubmodelServiceSpecification/SSP-002`

Closes #608