### PR TITLE
[V3.1.3 Backport] fix(bnf,schema): harmonize SecurityQueryFilter and add FILTERLIST

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -53,6 +53,7 @@ Major Changes:
 
 Minor Changes:
 
+* fix: Harmonized `SecurityQueryFilter` between API and Security specifications and added missing `FILTERLIST` construct to the BNF grammar and JSON Schema.
 * fix: Wrong ServiceSpecificationProfileEnum values for v3.0 profiles. (https://github.com/admin-shell-io/aas-specs-api/issues/526[#526])
 * removed: Remove TREE. (https://github.com/admin-shell-io/aas-specs-api/issues/537)
 * fix: fixed FILTER object in json schema & fixed inconsistencies in BNF (https://github.com/admin-shell-io/aas-specs-api/issues/547)

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
@@ -12,6 +12,10 @@
       "type": "string",
       "pattern": "^(?:\\$aas#(?:idShort|id|assetInformation\\.assetKind|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|submodels\\[[0-9]*\\]\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))|\\$sm#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|value|valueType|language)|\\$cd#(?:idShort|id)|\\$aasdesc#(?:idShort|id|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)|submodelDescriptors\\[[0-9]*\\]\\.(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))|\\$smdesc#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))$"
     },
+    "FragmentFieldIdentifier": {
+      "type": "string",
+      "pattern": "^(?:\\$aas#(?:idShort|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|submodels\\[[0-9]*\\](?:\\.keys\\[[0-9]*\\])?)|\\$sm#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?(?:#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|value|valueType|language))?|\\$cd#idShort|\\$aasdesc#(?:idShort|description|displayName|extension|administration|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|endpoints\\[[0-9]*\\]|submodelDescriptors\\[[0-9]*\\](?:\\.(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))?)|\\$smdesc#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))$"
+    },
     "hexLiteralPattern": {
       "type": "string",
       "pattern": "^16#[0-9A-F]+$"
@@ -653,6 +657,12 @@
         "FILTER": {
           "$ref": "#/definitions/SecurityQueryFilter",
           "additionalProperties": false
+        },
+        "FILTERLIST": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityQueryFilter"
+          }
         }
       },
       "allOf": [
@@ -705,7 +715,7 @@
       "type": "object",
       "properties": {
         "FRAGMENT": {
-          "type": "string"
+          "$ref": "#/definitions/FragmentFieldIdentifier"
         },
         "CONDITION": {
           "$ref": "#/definitions/logicalExpression"

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/bnf/grammar.bnf
@@ -93,17 +93,18 @@
     ( "DEFFORMULAS" <ws> <StringLiteral> <ws> <logicalExpression> <ws> )* 
     ( <AccessPermissionRule> <ws> )*
  
-<AccessPermissionRule> ::= 
+<AccessPermissionRule> ::=
     "ACCESSRULE:" <ws>
-    ( <ACL> | <UseACL> ) <ws> 
-    "OBJECTS:" <ws> 
-    ( <SingleObject> <ws> )* 
-    ( <UseObjectGroup> <ws> )* 
+    ( <ACL> | <UseACL> ) <ws>
+    "OBJECTS:" <ws>
+    ( <SingleObject> <ws> )*
+    ( <UseObjectGroup> <ws> )*
     ( ( "FORMULA:" <ws> <logicalExpression> <ws> ) | ( <UseFormula> <ws> ) )
     ( "FILTER:" <ws> <SecurityQueryFilter> )?
+    ( "FILTERLIST:" <ws> ( <SecurityQueryFilter> <ws> )* )?
 
 <SecurityQueryFilter> ::=
-    <FragmentObject> <ws>
+    ( "FRAGMENT:" <ws> <FieldIdentifierFragment> <ws> )
     ( ( "CONDITION:" <ws> <logicalExpression> <ws> ) | ( <UseFormula> <ws> ) )
 
 <ACL> ::= 
@@ -211,5 +212,20 @@
 <SpecificAssetIdsClause> ::=  ( "specificAssetIds" ( "[" ( [0-9]* ) "]" ) ( ".name" | ".value" | ".externalSubjectId" | ".externalSubjectId." <ReferenceClause> ) )
 <idShortPath> ::= ( <idShort> ("[" ( [0-9]* ) "]" )* ( "." <idShortPath> )* )
 <idShort> ::= ( ( [a-z] | [A-Z] ) (( [a-z] | [A-Z] | [0-9] | "_"   | "-" )* ( [a-z] | [A-Z] | [0-9] | "_" ) )? )
+
+<FieldIdentifierFragment> ::= <FieldIdentifierAASFragment> | <FieldIdentifierSMFragment> | <FieldIdentifierSMEFragment> | <FieldIdentifierCDFragment> | <FieldIdentifierAasDescriptorFragment> | <FieldIdentifierSmDescriptorFragment>
+
+<FieldIdentifierAASFragment> ::= "$aas#" ( "idShort" | "assetInformation.assetType" | "assetInformation.globalAssetId" | "assetInformation." <SpecificAssetIdsClauseFragment> | "submodels" ( "[" ( [0-9]* ) "]" ) ("." <ReferenceClauseFragment>)? )
+<FieldIdentifierSMFragment> ::= "$sm#" ( <SemanticIdClauseFragment> | "idShort" | "id" )
+<FieldIdentifierSMEFragment> ::= "$sme" ( "." <idShortPath> )? ( "#" ( <SemanticIdClauseFragment> | "idShort" | "value" | "valueType" | "language" ))?
+<FieldIdentifierCDFragment> ::= "$cd#" ( "idShort" ) <ws>
+<FieldIdentifierAasDescriptorFragment> ::= "$aasdesc#" ( "idShort" | "description" | "displayName" | "extension" | "administration" | "assetKind" | "assetType" | "globalAssetId" | <SpecificAssetIdsClauseFragment> | <EndpointClauseFragment> |  "submodelDescriptors[" ( [0-9]* ) "]" ("." <SmDescriptorClauseFragment>)? )
+<FieldIdentifierSmDescriptorFragment> ::= "$smdesc#" <SmDescriptorClauseFragment>
+
+<SpecificAssetIdsClauseFragment> ::= "specificAssetIds" ( "[" ( [0-9]* ) "]" ) (".externalSubjectId" | ".externalSubjectId." <ReferenceClauseFragment>)?
+<SmDescriptorClauseFragment> ::= ( <SemanticIdClauseFragment> | "idShort" | <EndpointClauseFragment> )
+<EndpointClauseFragment> ::= "endpoints" ( "[" ( [0-9]* ) "]" )
+<ReferenceClauseFragment> ::= ( "keys" ( "[" ( [0-9]* ) "]" ) )
+<SemanticIdClauseFragment> ::= ( "semanticId" | "semanticId." <ReferenceClauseFragment> )
 
 <ws> ::= ( " " | "\t" | "\r" | "\n" )*

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
@@ -12,6 +12,10 @@
       "type": "string",
       "pattern": "^(?:\\$aas#(?:idShort|id|assetInformation\\.assetKind|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|submodels\\[[0-9]*\\]\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))|\\$sm#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|value|valueType|language)|\\$cd#(?:idShort|id)|\\$aasdesc#(?:idShort|id|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\]\\.(?:name|value|externalSubjectId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?)|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)|submodelDescriptors\\[[0-9]*\\]\\.(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))|\\$smdesc#(?:semanticId(?:\\.(?:type|keys\\[[0-9]*\\]\\.(?:type|value)))?|idShort|id|endpoints\\[[0-9]*\\]\\.(?:interface|protocolinformation\\.href)))$"
     },
+    "FragmentFieldIdentifier": {
+      "type": "string",
+      "pattern": "^(?:\\$aas#(?:idShort|assetInformation\\.assetType|assetInformation\\.globalAssetId|assetInformation\\.specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|submodels\\[[0-9]*\\](?:\\.keys\\[[0-9]*\\])?)|\\$sm#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|id)|\\$sme(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*(?:\\.[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9_])?(?:\\[[0-9]*\\])*)*)?(?:#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|value|valueType|language))?|\\$cd#idShort|\\$aasdesc#(?:idShort|description|displayName|extension|administration|assetKind|assetType|globalAssetId|specificAssetIds\\[[0-9]*\\](?:\\.externalSubjectId(?:\\.keys\\[[0-9]*\\])?)?|endpoints\\[[0-9]*\\]|submodelDescriptors\\[[0-9]*\\](?:\\.(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))?)|\\$smdesc#(?:semanticId(?:\\.keys\\[[0-9]*\\])?|idShort|endpoints\\[[0-9]*\\]))$"
+    },
     "hexLiteralPattern": {
       "type": "string",
       "pattern": "^16#[0-9A-F]+$"
@@ -637,6 +641,12 @@
         "FILTER": {
           "$ref": "#/definitions/SecurityQueryFilter",
           "additionalProperties": false
+        },
+        "FILTERLIST": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SecurityQueryFilter"
+          }
         }
       },
       "allOf": [
@@ -689,7 +699,7 @@
       "type": "object",
       "properties": {
         "FRAGMENT": {
-          "type": "string"
+          "$ref": "#/definitions/FragmentFieldIdentifier"
         },
         "CONDITION": {
           "$ref": "#/definitions/logicalExpression"


### PR DESCRIPTION
## Backport from PR #579

This is a backport of the bugfix from PR #579 to the V3.1.3 release branch.

### Original PR Description

This PR addresses incompatibilities between the API and Security specifications regarding `SecurityQueryFilter` and the missing `FILTERLIST` construct.

**Core Problem:** The API and Security specs defined `SecurityQueryFilter` differently, making them syntactically incompatible. Additionally, the API grammar lacked `FILTERLIST` entirely.

**Solution:** The Security spec's definition is adopted as canonical. The PR rewrites `<SecurityQueryFilter>` to use `"FRAGMENT:" <FieldIdentifierFragment>` instead of `<FragmentObject>`, adds `FILTERLIST` support to `<AccessPermissionRule>`, and ports the `<FieldIdentifierFragment>` production family from the security spec.

### Changes
- BNF: Harmonized filter definitions; added optional `FILTERLIST` block
- JSON Schema: New `FragmentFieldIdentifier` definition with regex validation

### Related
- Original PR: #579
- Target: V3.1.3 release (IDTA-01001-3-1-3_working)