### PR TITLE
[V3.1.3 Backport] fix(schema): use anyOf where BNF allows mixed inline and named groups

### DIFF
--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -53,6 +53,7 @@ Major Changes:
 
 Minor Changes:
 
+* fix: Changed JSON Schema validation from `oneOf` to `anyOf` where BNF grammar allows mixed inline and named groups in concatenation scenarios.
 * fix: Wrong ServiceSpecificationProfileEnum values for v3.0 profiles. (https://github.com/admin-shell-io/aas-specs-api/issues/526[#526])
 * removed: Remove TREE. (https://github.com/admin-shell-io/aas-specs-api/issues/537)
 * fix: fixed FILTER object in json schema & fixed inconsistencies in BNF (https://github.com/admin-shell-io/aas-specs-api/issues/547)

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
@@ -607,7 +607,7 @@
         "RIGHTS",
         "ACCESS"
       ],
-      "oneOf": [
+      "anyOf": [
         {
           "required": [
             "ATTRIBUTES"
@@ -671,7 +671,7 @@
           ]
         },
         {
-          "oneOf": [
+          "anyOf": [
             {
               "required": [
                 "OBJECTS"

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
@@ -591,7 +591,7 @@
         "RIGHTS",
         "ACCESS"
       ],
-      "oneOf": [
+      "anyOf": [
         {
           "required": [
             "ATTRIBUTES"
@@ -655,7 +655,7 @@
           ]
         },
         {
-          "oneOf": [
+          "anyOf": [
             {
               "required": [
                 "OBJECTS"


### PR DESCRIPTION
## Backport from PR #581

This is a backport of the bugfix from PR #581 to the V3.1.3 release branch.

### Original PR Description

This PR addresses a mismatch between BNF grammar and JSON Schema validation. The BNF distinguishes between concatenation (allowing mixed variants) and alternation (exactly one), but the schemas incorrectly used `oneOf` for concatenation cases.

**Changes Made:**
- Converted `oneOf` to `anyOf` for three concatenation pairs:
  - ACL.{ATTRIBUTES, USEATTRIBUTES}
  - AccessPermissionRule.{OBJECTS, USEOBJECTS}
  - DEFATTRIBUTES item.{attributes, USEATTRIBUTES}
- Retained `oneOf` for true XOR scenarios (ACL/USEACL, FORMULA/USEFORMULA pairs)

**Impact:** This relaxes schema validation to align with grammar specifications. Previously valid documents remain valid; additionally, documents combining inline and named groups now validate correctly.

### Related
- Original PR: #581
- Target: V3.1.3 release (IDTA-01001-3-1-3_working)