### PR TITLE
Fix response payload type for PutSubmodelById

### DIFF
--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.1_SSP-001.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.1_SSP-001.yaml
@@ -540,7 +540,7 @@ paths:
         required: true
       responses:
         '201':
-          description: Submodel reference created successfully
+          description: Submodel created successfully
           headers:
             Location:
               description: URL of the newly created resource
@@ -549,7 +549,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.2#/components/schemas/Reference'
+                $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.1.2#/components/schemas/Submodel'
         '204':
           description: Submodel updated successfully
         '400':

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -9,6 +9,17 @@
 Note: Changes in Metamodel (IDTA-01001) will not be listed here, although they have an impact on the payload of many operations.
 ====
 
+== Changes w.r.t. V3.1.2 to V3.1.3
+
+Major Changes:
+
+* ...
+
+
+Minor Changes:
+
+* Fixed the response payload type of `PutSubmodelById` in the Asset Administration Shell Repository OpenAPI files: status code `201` now returns a `Submodel` instead of a `Reference`. (https://github.com/admin-shell-io/aas-specs-api/issues/601[#601])
+
 
 == Changes w.r.t. V3.1.1 to V3.1.2
 


### PR DESCRIPTION
This pull request fixes the response payload type for the `PutSubmodelById` operation in the Asset Administration Shell Repository OpenAPI specification. Specifically, when a submodel is created (status code 201), the response now correctly returns a `Submodel` object instead of a `Reference`. The changelog has also been updated to reflect this fix.

**API Specification Fixes:**

* The description for the 201 response in `AssetAdministrationShellRepositoryServiceSpecification/V3.1_SSP-001.yaml` was updated to clarify that a submodel is created, not a reference.
* The response schema for status code 201 now returns a `Submodel` instead of a `Reference` for the `PutSubmodelById` operation.

**Documentation Updates:**

* The changelog (`changelog.adoc`) now documents this fix under minor changes, referencing the related issue.

## Related Issue

See #601 