### PR TITLE
Fix response contracts in Discovery OpenAPI files (3.2 Port)

### DIFF
--- a/DiscoveryServiceSpecification/V3.2_SSP-001.yaml
+++ b/DiscoveryServiceSpecification/V3.2_SSP-001.yaml
@@ -134,11 +134,7 @@ paths:
                 items:
                   $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.2.0#/components/schemas/SpecificAssetId'
         '400':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/bad-request'
-        '404':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/not-found'
-        '409':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/conflict'
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.2#/components/responses/bad-request'
         default:
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/default'
     delete:

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7417,11 +7417,7 @@ paths:
                 items:
                   $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part1-MetaModel-Schemas/V3.2.0#/components/schemas/SpecificAssetId'
         '400':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/bad-request'
-        '404':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/not-found'
-        '409':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/conflict'
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.2#/components/responses/bad-request'
         default:
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/default'
     delete:

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -9,6 +9,19 @@
 Note: Changes in Metamodel (IDTA-01001) will not be listed here, although they have an impact on the payload of many operations.
 ====
 
+== Changes w.r.t. V3.1.2 to V3.1.3
+
+Major Changes:
+
+* ...
+
+
+Minor Changes:
+
+* Fixed the response payload type of `PutSubmodelById` in the Asset Administration Shell Repository OpenAPI files: status code `201` now returns a `Submodel` instead of a `Reference`. (https://github.com/admin-shell-io/aas-specs-api/issues/601[#601])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `404` for `POST /lookup/shells/{aasIdentifier}` to align with create-or-replace semantics. (https://github.com/admin-shell-io/aas-specs-api/issues/595[#595])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `409` for `POST /lookup/shells/{aasIdentifier}` to align with replace/update behavior on repeated payloads. (https://github.com/admin-shell-io/aas-specs-api/issues/596[#596])
+
 
 == Changes w.r.t. V3.1.2 to V3.2
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -75,6 +75,7 @@ Minor Changes:
 * Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `404` for `POST /lookup/shells/{aasIdentifier}` to align with create-or-replace semantics. (https://github.com/admin-shell-io/aas-specs-api/issues/595[#595])
 * Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `409` for `POST /lookup/shells/{aasIdentifier}` to align with replace/update behavior on repeated payloads. (https://github.com/admin-shell-io/aas-specs-api/issues/596[#596])
 
+
 == Changes w.r.t. V3.1.1 to V3.1.2
 
 Major Changes:

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -9,19 +9,6 @@
 Note: Changes in Metamodel (IDTA-01001) will not be listed here, although they have an impact on the payload of many operations.
 ====
 
-== Changes w.r.t. V3.1.2 to V3.1.3
-
-Major Changes:
-
-* ...
-
-
-Minor Changes:
-
-* Fixed the response payload type of `PutSubmodelById` in the Asset Administration Shell Repository OpenAPI files: status code `201` now returns a `Submodel` instead of a `Reference`. (https://github.com/admin-shell-io/aas-specs-api/issues/601[#601])
-* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `404` for `POST /lookup/shells/{aasIdentifier}` to align with create-or-replace semantics. (https://github.com/admin-shell-io/aas-specs-api/issues/595[#595])
-* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `409` for `POST /lookup/shells/{aasIdentifier}` to align with replace/update behavior on repeated payloads. (https://github.com/admin-shell-io/aas-specs-api/issues/596[#596])
-
 
 == Changes w.r.t. V3.1.2 to V3.2
 
@@ -75,6 +62,18 @@ h|Operation  h|Kind of Change h|Comment
 |===
 
 
+== Changes w.r.t. V3.1.2 to V3.1.3
+
+Major Changes:
+
+* ...
+
+
+Minor Changes:
+
+* Fixed the response payload type of `PutSubmodelById` in the Asset Administration Shell Repository OpenAPI files: status code `201` now returns a `Submodel` instead of a `Reference`. (https://github.com/admin-shell-io/aas-specs-api/issues/601[#601])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `404` for `POST /lookup/shells/{aasIdentifier}` to align with create-or-replace semantics. (https://github.com/admin-shell-io/aas-specs-api/issues/595[#595])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `409` for `POST /lookup/shells/{aasIdentifier}` to align with replace/update behavior on repeated payloads. (https://github.com/admin-shell-io/aas-specs-api/issues/596[#596])
 
 == Changes w.r.t. V3.1.1 to V3.1.2
 


### PR DESCRIPTION
This pull request updates the AAS Discovery response contract for POST `/lookup/shells/{aasIdentifier}` to align with the operation’s effective create-or-replace behavior. Specifically, 404 Not Found and 409 Conflict were removed from the documented responses for this operation, so the contract now reflects successful create/update via 201, invalid requests via 400, and generic errors via default. The changelog for 3.1.3 was also extended to document both fixes.

**API Specification Fixes:**

- Updated `V3.1_SSP-001.yaml` for PostAllAssetLinksById:
  - Removed 404 Not Found from POST `/lookup/shells/{aasIdentifier}`
  - Removed 409 Conflict from POST `/lookup/shells/{aasIdentifier}`
- Mirrored the same response-contract changes in `V3.1.yaml` to keep the aggregated OpenAPI specification consistent.

**Documentation Updates:**

- Updated `changelog.adoc` under Changes w.r.t. V3.1.2 to V3.1.3 (Minor Changes):
  - Added entry for issue 595 (remove 404 for POST /lookup/shells/{aasIdentifier})
  - Added entry for issue 596 (remove 409 for POST /lookup/shells/{aasIdentifier})

## Related Issues

See #595 and #596

Cherry picked bf0978825a9a93ec022df3d39b8fc11886b5ae1f from #616

## IMPORTANT!

Merge #602 first