### PR TITLE
Removes wrong 404 status code for getAllSubmodelDescriptors (3.2 Port)

### DIFF
--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7058,9 +7058,7 @@ paths:
         '400':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/bad-request'
         '403':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/forbidden'
-        '404':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/not-found'
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.2#/components/responses/forbidden'
         '500':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/internal-server-error'    
         default:

--- a/SubmodelRegistryServiceSpecification/V3.2_SSP-001.yaml
+++ b/SubmodelRegistryServiceSpecification/V3.2_SSP-001.yaml
@@ -38,9 +38,7 @@ paths:
         '400':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/bad-request'
         '403':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/forbidden'
-        '404':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/not-found'
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.2#/components/responses/forbidden'
         '500':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/internal-server-error'    
         default:

--- a/SubmodelRegistryServiceSpecification/V3.2_SSP-002.yaml
+++ b/SubmodelRegistryServiceSpecification/V3.2_SSP-002.yaml
@@ -38,9 +38,7 @@ paths:
         '400':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/bad-request'
         '403':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/forbidden'
-        '404':
-          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/not-found'
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.2#/components/responses/forbidden'
         '500':
           $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.2.0#/components/responses/internal-server-error'    
         default:

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -9,6 +9,20 @@
 Note: Changes in Metamodel (IDTA-01001) will not be listed here, although they have an impact on the payload of many operations.
 ====
 
+== Changes w.r.t. V3.1.2 to V3.1.3
+
+Major Changes:
+
+* ...
+
+
+Minor Changes:
+
+* Fixed the response payload type of `PutSubmodelById` in the Asset Administration Shell Repository OpenAPI files: status code `201` now returns a `Submodel` instead of a `Reference`. (https://github.com/admin-shell-io/aas-specs-api/issues/601[#601])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `404` for `POST /lookup/shells/{aasIdentifier}` to align with create-or-replace semantics. (https://github.com/admin-shell-io/aas-specs-api/issues/595[#595])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `409` for `POST /lookup/shells/{aasIdentifier}` to align with replace/update behavior on repeated payloads. (https://github.com/admin-shell-io/aas-specs-api/issues/596[#596])
+* Updated the response contract of `GetAllSubmodelDescriptors` in Submodel Registry OpenAPI files by removing status code `404` for `GET /submodel-descriptors`, so an empty collection is consistently represented by `200` with an empty result. (https://github.com/admin-shell-io/aas-specs-api/issues/597[#597])
+
 
 == Changes w.r.t. V3.1.2 to V3.2
 

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -9,20 +9,6 @@
 Note: Changes in Metamodel (IDTA-01001) will not be listed here, although they have an impact on the payload of many operations.
 ====
 
-== Changes w.r.t. V3.1.2 to V3.1.3
-
-Major Changes:
-
-* ...
-
-
-Minor Changes:
-
-* Fixed the response payload type of `PutSubmodelById` in the Asset Administration Shell Repository OpenAPI files: status code `201` now returns a `Submodel` instead of a `Reference`. (https://github.com/admin-shell-io/aas-specs-api/issues/601[#601])
-* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `404` for `POST /lookup/shells/{aasIdentifier}` to align with create-or-replace semantics. (https://github.com/admin-shell-io/aas-specs-api/issues/595[#595])
-* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `409` for `POST /lookup/shells/{aasIdentifier}` to align with replace/update behavior on repeated payloads. (https://github.com/admin-shell-io/aas-specs-api/issues/596[#596])
-* Updated the response contract of `GetAllSubmodelDescriptors` in Submodel Registry OpenAPI files by removing status code `404` for `GET /submodel-descriptors`, so an empty collection is consistently represented by `200` with an empty result. (https://github.com/admin-shell-io/aas-specs-api/issues/597[#597])
-
 
 == Changes w.r.t. V3.1.2 to V3.2
 
@@ -75,6 +61,20 @@ h|Operation  h|Kind of Change h|Comment
  | PutAssetAdministrationShellById|change a| Added the missing `id` input parameter and a note explaining the behavior in case the AAS identifier does not match the value of `id`. (https://github.com/admin-shell-io/aas-specs-api/issues/506[#506])
 |===
 
+
+== Changes w.r.t. V3.1.2 to V3.1.3
+
+Major Changes:
+
+* ...
+
+
+Minor Changes:
+
+* Fixed the response payload type of `PutSubmodelById` in the Asset Administration Shell Repository OpenAPI files: status code `201` now returns a `Submodel` instead of a `Reference`. (https://github.com/admin-shell-io/aas-specs-api/issues/601[#601])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `404` for `POST /lookup/shells/{aasIdentifier}` to align with create-or-replace semantics. (https://github.com/admin-shell-io/aas-specs-api/issues/595[#595])
+* Updated the response contract of `PostAllAssetLinksById` in Discovery OpenAPI files by removing status code `409` for `POST /lookup/shells/{aasIdentifier}` to align with replace/update behavior on repeated payloads. (https://github.com/admin-shell-io/aas-specs-api/issues/596[#596])
+* Updated the response contract of `GetAllSubmodelDescriptors` in Submodel Registry OpenAPI files by removing status code `404` for `GET /submodel-descriptors`, so an empty collection is consistently represented by `200` with an empty result. (https://github.com/admin-shell-io/aas-specs-api/issues/597[#597])
 
 
 == Changes w.r.t. V3.1.1 to V3.1.2


### PR DESCRIPTION
This pull request aligns the Submodel Registry response contract for GET `/submodel-descriptors` with collection semantics.
When no submodel descriptors exist, the endpoint returns 200 OK with an empty result set, so documenting 404 Not Found for this operation was misleading. This PR removes that ambiguity and updates the changelog accordingly.

**API Specification Fixes:**

- Removed 404 Not Found from GET `/submodel-descriptors` in the Submodel Registry full profile:
`V3.2_SSP-001.yaml`
- Removed 404 Not Found from GET `/submodel-descriptors` in the Submodel Registry read profile:
`V3.2_SSP-002.yaml`
- Applied the same change in the aggregated OpenAPI collection:
`V3.2.yaml`

**Documentation Updates:**

- Added a 3.1.3 minor-change entry describing this fix and referencing issue 597:
`changelog.adoc`

## Related Issues

See #597 

Cherry picked 30bd9befbb45bf929c420789738718c1fe60b622 and 0d21dcb537ea9f6f45c292ea9b9c107e4d2fc04c from #617

## IMPORTANT!

Merge #618 first