### PR TITLE
Align the history retrieval contract

### DIFF
--- a/AssetAdministrationShellRegistryServiceSpecification/V3.2_SSP-003.yaml
+++ b/AssetAdministrationShellRegistryServiceSpecification/V3.2_SSP-003.yaml
@@ -102,6 +102,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"
@@ -122,11 +123,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetAsyncBulkStatus/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '200':
           description:   Bulk operation result object containing information that the
@@ -160,11 +157,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '204':
           description:   The bulk request itself was correct and all elements have been

--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-001.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-001.yaml
@@ -541,7 +541,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -737,7 +736,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-002.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-002.yaml
@@ -280,7 +280,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -344,7 +343,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/AssetAdministrationShellServiceSpecification/V3.2_SSP-001.yaml
+++ b/AssetAdministrationShellServiceSpecification/V3.2_SSP-001.yaml
@@ -1409,7 +1409,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-asnyc:
+  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
@@ -1478,7 +1478,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1512,7 +1511,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1544,7 +1542,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -344,7 +344,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -549,7 +548,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -3428,7 +3426,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -3636,7 +3633,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -5004,7 +5000,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -5131,9 +5126,9 @@ paths:
       tags:
         - Submodel Repository API
       summary: Returns a specific Submodel valid at a specific point in time
-      operationId: GetSubmodelByIdAndDate
+      operationId: GetSubmodelVersionByIdAndDate
       x-semanticIds:
-        - https://admin-shell.io/aas/API/GetSubmodelByIdAndDate/3/2
+        - https://admin-shell.io/aas/API/GetSubmodelVersionByIdAndDate/3/2
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
@@ -5239,7 +5234,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -1430,7 +1430,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-asnyc:
+  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
@@ -1499,7 +1499,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1533,7 +1532,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1565,7 +1563,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -6156,7 +6153,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:
@@ -6233,7 +6229,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7133,6 +7133,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"
@@ -7153,11 +7154,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/BulkGetAsyncStatus/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '200':
           description:   Bulk operation result object containing information that the
@@ -7189,11 +7186,7 @@ paths:
       summary: Returns the result object of an asynchronously invoked bulk operation
       operationId: BulkGetAsyncResult
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/2
       responses:
@@ -7471,6 +7464,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"

--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -73,7 +73,7 @@ components:
       name: date
       in: query
       description: Date and time of the requested version of the Identifiable in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-      required: true
+      required: false
       schema:
         type: string
         format: date-time

--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -234,7 +234,7 @@ components:
               type: string
               minLength: 1
               maxLength: 2048
-              pattern: ^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$
+              pattern: "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             globalAssetId:
               type: string
               minLength: 1
@@ -321,7 +321,9 @@ components:
               type: string
               minLength: 1
               maxLength: 2048
-              pattern: ^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$
+              pattern: "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
+          required:
+            - id
     comparisonItems:
       type: array
       minItems: 2
@@ -1283,7 +1285,7 @@ components:
               type: string
               minLength: 1
               maxLength: 2048
-              pattern: ^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$
+              pattern: "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             semanticId:
               $ref: "../Part1-MetaModel-Schemas/openapi.yaml#/components/schemas/Reference"
             supplementalSemanticIds:

--- a/SubmodelRegistryServiceSpecification/V3.2_SSP-003.yaml
+++ b/SubmodelRegistryServiceSpecification/V3.2_SSP-003.yaml
@@ -95,6 +95,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"
@@ -115,11 +116,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncStatus/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '200':
           description: Bulk operation result object containing information that the
@@ -153,11 +150,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '204':
           description: The bulk request itself was correct and all elements have been

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
@@ -489,7 +489,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
@@ -1372,7 +1372,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:
@@ -1449,7 +1448,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-002.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-002.yaml
@@ -250,7 +250,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -312,7 +311,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-007.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-007.yaml
@@ -25,9 +25,9 @@ paths:
       tags:
         - Submodel Repository API
       summary: Returns a specific Submodel valid at a specific point in time
-      operationId: GetSubmodelByIdAndDate
+      operationId: GetSubmodelVersionByIdAndDate
       x-semanticIds:
-        - https://admin-shell.io/aas/API/GetSubmodelByIdAndDate/3/2
+        - https://admin-shell.io/aas/API/GetSubmodelVersionByIdAndDate/3/2
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Corrected the AAS Service asynchronous invocation path from `/invoke-asnyc` to `/invoke-async` and removed undeclared `aasIdentifier` parameters from submodel operation routes.
 * fix: Changed JSON Schema validation from `oneOf` to `anyOf` where BNF grammar allows mixed inline and named groups in concatenation scenarios.
 * docs: Aligned prose tables in Query Language specification with BNF grammar and JSON Schema patterns for cast operators, field identifiers, and submodel element limitations.
 * docs: Added normative FieldIdentifier applicability table per profile to clarify which Query and Access Rule prefixes apply to specific service specification families.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Marked bulk DELETE request bodies as required and corrected the reusable `handleId` parameter references in the asynchronous registry bulk profiles.
 * fix: Corrected the AAS Service asynchronous invocation path from `/invoke-asnyc` to `/invoke-async` and removed undeclared `aasIdentifier` parameters from submodel operation routes.
 * fix: Changed JSON Schema validation from `oneOf` to `anyOf` where BNF grammar allows mixed inline and named groups in concatenation scenarios.
 * docs: Aligned prose tables in Query Language specification with BNF grammar and JSON Schema patterns for cast operators, field identifiers, and submodel element limitations.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
@@ -49,11 +49,207 @@
     },
     "dateTimeLiteralPattern": {
       "type": "string",
-      "format": "date-time"
+      "pattern": "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?$"
     },
     "timeLiteralPattern": {
       "type": "string",
-      "pattern": "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?(\\.[0-9]+)?(Z|[+-][0-9][0-9]:[0-9][0-9])?$"
+      "pattern": "^(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?$"
+    },
+    "dateTimeAttributeItem": {
+      "type": "object",
+      "properties": {
+        "GLOBAL": {
+          "type": "string",
+          "enum": [
+            "LOCALNOW",
+            "UTCNOW",
+            "CLIENTNOW"
+          ]
+        }
+      },
+      "required": [
+        "GLOBAL"
+      ],
+      "additionalProperties": false
+    },
+    "dateTimeOperand": {
+      "type": "object",
+      "properties": {
+        "$dateTimeVal": {
+          "$ref": "#/definitions/dateTimeLiteralPattern"
+        },
+        "$dateTimeCast": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "$attribute": {
+          "$ref": "#/definitions/dateTimeAttributeItem"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$dateTimeVal"
+          ]
+        },
+        {
+          "required": [
+            "$dateTimeCast"
+          ]
+        },
+        {
+          "required": [
+            "$attribute"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "fieldOperand": {
+      "type": "object",
+      "properties": {
+        "$field": {
+          "$ref": "#/definitions/FieldIdentifier"
+        }
+      },
+      "required": [
+        "$field"
+      ],
+      "additionalProperties": false
+    },
+    "numericalOperand": {
+      "type": "object",
+      "properties": {
+        "$numVal": {
+          "type": "number"
+        },
+        "$numCast": {
+          "$ref": "#/definitions/Value"
+        },
+        "$dayOfWeek": {
+          "$ref": "#/definitions/dateTimeOperand"
+        },
+        "$dayOfMonth": {
+          "$ref": "#/definitions/dateTimeOperand"
+        },
+        "$month": {
+          "$ref": "#/definitions/dateTimeOperand"
+        },
+        "$year": {
+          "$ref": "#/definitions/dateTimeOperand"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$numVal"
+          ]
+        },
+        {
+          "required": [
+            "$numCast"
+          ]
+        },
+        {
+          "required": [
+            "$dayOfWeek"
+          ]
+        },
+        {
+          "required": [
+            "$dayOfMonth"
+          ]
+        },
+        {
+          "required": [
+            "$month"
+          ]
+        },
+        {
+          "required": [
+            "$year"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "hexOperand": {
+      "type": "object",
+      "properties": {
+        "$hexVal": {
+          "$ref": "#/definitions/hexLiteralPattern"
+        },
+        "$hexCast": {
+          "$ref": "#/definitions/Value"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$hexVal"
+          ]
+        },
+        {
+          "required": [
+            "$hexCast"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "boolOperand": {
+      "type": "object",
+      "properties": {
+        "$boolean": {
+          "type": "boolean"
+        },
+        "$boolCast": {
+          "$ref": "#/definitions/Value"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$boolean"
+          ]
+        },
+        {
+          "required": [
+            "$boolCast"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "timeOperand": {
+      "type": "object",
+      "properties": {
+        "$timeVal": {
+          "$ref": "#/definitions/timeLiteralPattern"
+        },
+        "$timeCast": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/stringValue"
+            },
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            }
+          ]
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$timeVal"
+          ]
+        },
+        {
+          "required": [
+            "$timeCast"
+          ]
+        }
+      ],
+      "additionalProperties": false
     },
     "Value": {
       "type": "object",
@@ -95,50 +291,29 @@
           "$ref": "#/definitions/Value"
         },
         "$dateTimeCast": {
-          "$ref": "#/definitions/Value"
+          "$ref": "#/definitions/stringValue"
         },
         "$timeCast": {
-          "$ref": "#/definitions/Value"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/stringValue"
+            },
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            }
+          ]
         },
         "$dayOfWeek": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         },
         "$dayOfMonth": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         },
         "$month": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         },
         "$year": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         }
       },
       "oneOf": [
@@ -275,21 +450,301 @@
       ],
       "additionalProperties": false
     },
+    "stringNonFieldValue": {
+      "type": "object",
+      "properties": {
+        "$strVal": {
+          "$ref": "#/definitions/standardString"
+        },
+        "$strCast": {
+          "$ref": "#/definitions/Value"
+        },
+        "$attribute": {
+          "$ref": "#/definitions/attributeItem"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$strVal"
+          ]
+        },
+        {
+          "required": [
+            "$strCast"
+          ]
+        },
+        {
+          "required": [
+            "$attribute"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
     "comparisonItems": {
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 2,
-      "items": {
-        "$ref": "#/definitions/Value"
-      }
+      "$ref": "#/definitions/equalityComparisonItems"
     },
     "stringItems": {
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 2,
-      "items": {
-        "$ref": "#/definitions/stringValue"
-      }
+      "anyOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/stringValue"
+            },
+            {
+              "$ref": "#/definitions/stringNonFieldValue"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/stringNonFieldValue"
+            },
+            {
+              "$ref": "#/definitions/stringValue"
+            }
+          ]
+        }
+      ]
+    },
+    "numericalComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/numericalOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/numericalOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/numericalOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "hexComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/hexOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/hexOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/hexOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "boolComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/boolOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/boolOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/boolOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "dateTimeComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/dateTimeOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "timeComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/timeOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/timeOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/timeOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "equalityComparisonItems": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/stringItems"
+        },
+        {
+          "$ref": "#/definitions/numericalComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/hexComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/boolComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/dateTimeComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/timeComparisonItems"
+        }
+      ]
+    },
+    "orderedComparisonItems": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/stringItems"
+        },
+        {
+          "$ref": "#/definitions/numericalComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/hexComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/dateTimeComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/timeComparisonItems"
+        }
+      ]
     },
     "matchExpression": {
       "type": "object",
@@ -302,22 +757,22 @@
           }
         },
         "$eq": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$ne": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$gt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$ge": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$lt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$le": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$contains": {
           "$ref": "#/definitions/stringItems"
@@ -330,9 +785,6 @@
         },
         "$regex": {
           "$ref": "#/definitions/stringItems"
-        },
-        "$boolean": {
-          "type": "boolean"
         }
       },
       "oneOf": [
@@ -388,11 +840,6 @@
         },
         {
           "required": [
-            "$boolean"
-          ]
-        },
-        {
-          "required": [
             "$match"
           ]
         }
@@ -427,22 +874,22 @@
           "$ref": "#/definitions/logicalExpression"
         },
         "$eq": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$ne": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$gt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$ge": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$lt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$le": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$contains": {
           "$ref": "#/definitions/stringItems"


### PR DESCRIPTION
The reusable `date` parameter was marked as mandatory and had also leaked into ordinary Submodel retrieval operations. That made normal GET requests require a history timestamp, contrary to the abstract interface and the documented behavior. The Submodel history profile also used a different operation name and semantic identifier than the normative interface.

This change makes `date` optional, limits it to the two explicit `$history` operations, and renames the Submodel operation to `GetSubmodelVersionByIdAndDate` in the profile and combined API.

### Validation

- `openapi-spec-validator` passes for all six affected service profiles
- Parsed the combined API and verified that only the AAS and Submodel `$history` operations reference `date`
- Verified the canonical Submodel history operationId and semanticId
- `python tools/validate_spec_artifacts.py`
- `git diff --check`

### Merge order

Depends on #649. Merge #646 through #649 before this PR.