### PR TITLE
Repair the AASX documentation contracts

### DIFF
--- a/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
+++ b/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
@@ -138,7 +138,9 @@ paths:
           description: Requested Description
           content:
             application/json:
-              example: "https://admin-shell.io/aas/API/3/2/AasxFileServerServiceSpecification/SSP-002"
+              example:
+                profiles:
+                  - https://admin-shell.io/aas/API/3/2/AasxFileServerServiceSpecification/SSP-002
               schema:
                 $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/ServiceDescription'
         '400':

--- a/AssetAdministrationShellRegistryServiceSpecification/V3.2_SSP-003.yaml
+++ b/AssetAdministrationShellRegistryServiceSpecification/V3.2_SSP-003.yaml
@@ -102,6 +102,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"
@@ -122,11 +123,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetAsyncBulkStatus/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '200':
           description:   Bulk operation result object containing information that the
@@ -160,11 +157,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '204':
           description:   The bulk request itself was correct and all elements have been

--- a/AssetAdministrationShellRegistryServiceSpecification/V3.2_SSP-004.yaml
+++ b/AssetAdministrationShellRegistryServiceSpecification/V3.2_SSP-004.yaml
@@ -30,6 +30,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-001.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-001.yaml
@@ -541,7 +541,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -737,7 +736,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-002.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-002.yaml
@@ -280,7 +280,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -344,7 +343,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-003.yaml
+++ b/AssetAdministrationShellRepositoryServiceSpecification/V3.2_SSP-003.yaml
@@ -30,6 +30,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/AssetAdministrationShellServiceSpecification/V3.2_SSP-001.yaml
+++ b/AssetAdministrationShellServiceSpecification/V3.2_SSP-001.yaml
@@ -1409,7 +1409,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-asnyc:
+  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
@@ -1478,7 +1478,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1512,7 +1511,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1544,7 +1542,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:

--- a/ConceptDescriptionRepositoryServiceSpecification/V3.2_SSP-002.yaml
+++ b/ConceptDescriptionRepositoryServiceSpecification/V3.2_SSP-002.yaml
@@ -31,6 +31,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -344,7 +344,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -549,7 +548,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -3428,7 +3426,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -3636,7 +3633,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -5004,7 +5000,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -5131,9 +5126,9 @@ paths:
       tags:
         - Submodel Repository API
       summary: Returns a specific Submodel valid at a specific point in time
-      operationId: GetSubmodelByIdAndDate
+      operationId: GetSubmodelVersionByIdAndDate
       x-semanticIds:
-        - https://admin-shell.io/aas/API/GetSubmodelByIdAndDate/3/2
+        - https://admin-shell.io/aas/API/GetSubmodelVersionByIdAndDate/3/2
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
@@ -5239,7 +5234,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -4705,6 +4705,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -6362,6 +6363,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -6665,6 +6667,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -7027,6 +7030,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -7362,6 +7366,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -1430,7 +1430,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-asnyc:
+  /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
@@ -1499,7 +1499,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-status/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1533,7 +1532,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -1565,7 +1563,6 @@ paths:
   /aas/submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/operation-results/{handleId}/$value:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -6156,7 +6153,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:
@@ -6233,7 +6229,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7133,6 +7133,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"
@@ -7153,11 +7154,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/BulkGetAsyncStatus/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '200':
           description:   Bulk operation result object containing information that the
@@ -7189,11 +7186,7 @@ paths:
       summary: Returns the result object of an asynchronously invoked bulk operation
       operationId: BulkGetAsyncResult
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/2
       responses:
@@ -7471,6 +7464,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"

--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -73,7 +73,7 @@ components:
       name: date
       in: query
       description: Date and time of the requested version of the Identifiable in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
-      required: true
+      required: false
       schema:
         type: string
         format: date-time

--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -234,7 +234,7 @@ components:
               type: string
               minLength: 1
               maxLength: 2048
-              pattern: ^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$
+              pattern: "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             globalAssetId:
               type: string
               minLength: 1
@@ -321,7 +321,9 @@ components:
               type: string
               minLength: 1
               maxLength: 2048
-              pattern: ^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$
+              pattern: "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
+          required:
+            - id
     comparisonItems:
       type: array
       minItems: 2
@@ -1283,7 +1285,7 @@ components:
               type: string
               minLength: 1
               maxLength: 2048
-              pattern: ^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$
+              pattern: "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             semanticId:
               $ref: "../Part1-MetaModel-Schemas/openapi.yaml#/components/schemas/Reference"
             supplementalSemanticIds:

--- a/Part2-API-Schemas/openapi.yaml
+++ b/Part2-API-Schemas/openapi.yaml
@@ -325,11 +325,191 @@ components:
           required:
             - id
     comparisonItems:
+      $ref: '#/components/schemas/equalityComparisonItems'
+    fieldOperand:
+      type: object
+      properties:
+        $field:
+          $ref: '#/components/schemas/FieldIdentifier'
+      required:
+        - $field
+      additionalProperties: false
+    attributeItem:
+      type: object
+      properties:
+        CLAIM:
+          type: string
+        GLOBAL:
+          type: string
+          enum:
+            - LOCALNOW
+            - UTCNOW
+            - CLIENTNOW
+            - ANONYMOUS
+        REFERENCE:
+          type: string
+      oneOf:
+        - required:
+            - CLAIM
+        - required:
+            - GLOBAL
+        - required:
+            - REFERENCE
+      additionalProperties: false
+    dateTimeAttributeItem:
+      type: object
+      properties:
+        GLOBAL:
+          type: string
+          enum:
+            - LOCALNOW
+            - UTCNOW
+            - CLIENTNOW
+      required:
+        - GLOBAL
+      additionalProperties: false
+    dateTimeOperand:
+      type: object
+      properties:
+        $dateTimeVal:
+          $ref: '#/components/schemas/dateTimeLiteralPattern'
+        $dateTimeCast:
+          $ref: '#/components/schemas/stringValue'
+        $attribute:
+          $ref: '#/components/schemas/dateTimeAttributeItem'
+      oneOf:
+        - required:
+            - $dateTimeVal
+        - required:
+            - $dateTimeCast
+        - required:
+            - $attribute
+      additionalProperties: false
+    numericalOperand:
+      type: object
+      properties:
+        $numVal:
+          type: number
+        $numCast:
+          $ref: '#/components/schemas/Value'
+        $dayOfWeek:
+          $ref: '#/components/schemas/dateTimeOperand'
+        $dayOfMonth:
+          $ref: '#/components/schemas/dateTimeOperand'
+        $month:
+          $ref: '#/components/schemas/dateTimeOperand'
+        $year:
+          $ref: '#/components/schemas/dateTimeOperand'
+      oneOf:
+        - required:
+            - $numVal
+        - required:
+            - $numCast
+        - required:
+            - $dayOfWeek
+        - required:
+            - $dayOfMonth
+        - required:
+            - $month
+        - required:
+            - $year
+      additionalProperties: false
+    hexOperand:
+      type: object
+      properties:
+        $hexVal:
+          $ref: '#/components/schemas/hexLiteralPattern'
+        $hexCast:
+          $ref: '#/components/schemas/Value'
+      oneOf:
+        - required:
+            - $hexVal
+        - required:
+            - $hexCast
+      additionalProperties: false
+    boolOperand:
+      type: object
+      properties:
+        $boolean:
+          type: boolean
+        $boolCast:
+          $ref: '#/components/schemas/Value'
+      oneOf:
+        - required:
+            - $boolean
+        - required:
+            - $boolCast
+      additionalProperties: false
+    timeOperand:
+      type: object
+      properties:
+        $timeVal:
+          $ref: '#/components/schemas/timeLiteralPattern'
+        $timeCast:
+          anyOf:
+            - $ref: '#/components/schemas/stringValue'
+            - $ref: '#/components/schemas/dateTimeOperand'
+      oneOf:
+        - required:
+            - $timeVal
+        - required:
+            - $timeCast
+      additionalProperties: false
+    numericalComparisonItems:
       type: array
       minItems: 2
       maxItems: 2
       items:
-        $ref: '#/components/schemas/Value'
+        oneOf:
+          - $ref: '#/components/schemas/numericalOperand'
+          - $ref: '#/components/schemas/fieldOperand'
+    hexComparisonItems:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/hexOperand'
+          - $ref: '#/components/schemas/fieldOperand'
+    boolComparisonItems:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/boolOperand'
+          - $ref: '#/components/schemas/fieldOperand'
+    dateTimeComparisonItems:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/dateTimeOperand'
+          - $ref: '#/components/schemas/fieldOperand'
+    timeComparisonItems:
+      type: array
+      minItems: 2
+      maxItems: 2
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/timeOperand'
+          - $ref: '#/components/schemas/fieldOperand'
+    equalityComparisonItems:
+      anyOf:
+        - $ref: '#/components/schemas/stringItems'
+        - $ref: '#/components/schemas/numericalComparisonItems'
+        - $ref: '#/components/schemas/hexComparisonItems'
+        - $ref: '#/components/schemas/boolComparisonItems'
+        - $ref: '#/components/schemas/dateTimeComparisonItems'
+        - $ref: '#/components/schemas/timeComparisonItems'
+    orderedComparisonItems:
+      anyOf:
+        - $ref: '#/components/schemas/stringItems'
+        - $ref: '#/components/schemas/numericalComparisonItems'
+        - $ref: '#/components/schemas/hexComparisonItems'
+        - $ref: '#/components/schemas/dateTimeComparisonItems'
+        - $ref: '#/components/schemas/timeComparisonItems'
     dateTimeLiteralPattern:
       type: string
       pattern: "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?$"
@@ -577,17 +757,17 @@ components:
         $not:
           $ref: '#/components/schemas/logicalExpression'
         $eq:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/equalityComparisonItems'
         $ne:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/equalityComparisonItems'
         $gt:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $ge:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $lt:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $le:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $contains:
           $ref: '#/components/schemas/stringItems'
         $starts-with:
@@ -640,17 +820,17 @@ components:
           items:
             $ref: '#/components/schemas/matchExpression'
         $eq:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/equalityComparisonItems'
         $ne:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/equalityComparisonItems'
         $gt:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $ge:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $lt:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $le:
-          $ref: '#/components/schemas/comparisonItems'
+          $ref: '#/components/schemas/orderedComparisonItems'
         $contains:
           $ref: '#/components/schemas/stringItems'
         $starts-with:
@@ -659,8 +839,6 @@ components:
           $ref: '#/components/schemas/stringItems'
         $regex:
           $ref: '#/components/schemas/stringItems'
-        $boolean:
-          type: boolean
       oneOf:
         - required:
             - $eq
@@ -682,8 +860,6 @@ components:
             - $ends-with
         - required:
             - $regex
-        - required:
-            - $boolean
         - required:
             - $match
       additionalProperties: false
@@ -1166,6 +1342,8 @@ components:
           $ref: '#/components/schemas/standardString'
         $strCast:
           $ref: '#/components/schemas/Value'
+        $attribute:
+          $ref: '#/components/schemas/attributeItem'
       oneOf:
         - required:
             - $field
@@ -1173,6 +1351,8 @@ components:
             - $strVal
         - required:
             - $strCast
+        - required:
+            - $attribute
       additionalProperties: false
     StringValue: 
       type: string
@@ -1307,6 +1487,8 @@ components:
           $ref: '#/components/schemas/FieldIdentifier'
         $strVal:
           $ref: '#/components/schemas/standardString'
+        $attribute:
+          $ref: '#/components/schemas/attributeItem'
         $numVal:
           type: number
         $hexVal:
@@ -1326,17 +1508,19 @@ components:
         $boolCast:
           $ref: '#/components/schemas/Value'
         $dateTimeCast:
-          $ref: '#/components/schemas/Value'
+          $ref: '#/components/schemas/stringValue'
         $timeCast:
-          $ref: '#/components/schemas/Value'
+          anyOf:
+            - $ref: '#/components/schemas/stringValue'
+            - $ref: '#/components/schemas/dateTimeOperand'
         $dayOfWeek:
-          $ref: '#/components/schemas/dateTimeLiteralPattern'
+          $ref: '#/components/schemas/dateTimeOperand'
         $dayOfMonth:
-          $ref: '#/components/schemas/dateTimeLiteralPattern'
+          $ref: '#/components/schemas/dateTimeOperand'
         $month:
-          $ref: '#/components/schemas/dateTimeLiteralPattern'
+          $ref: '#/components/schemas/dateTimeOperand'
         $year:
-          $ref: '#/components/schemas/dateTimeLiteralPattern'
+          $ref: '#/components/schemas/dateTimeOperand'
       oneOf:
         - required:
             - $field

--- a/SubmodelRegistryServiceSpecification/V3.2_SSP-003.yaml
+++ b/SubmodelRegistryServiceSpecification/V3.2_SSP-003.yaml
@@ -95,6 +95,7 @@ paths:
               minItems: 1
               items:
                 type: string
+        required: true
       responses:
         '202':
           $ref: "../Part2-API-Schemas/openapi.yaml#/components/responses/accepted"
@@ -115,11 +116,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncStatus/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '200':
           description: Bulk operation result object containing information that the
@@ -153,11 +150,7 @@ paths:
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetBulkAsyncResult/3/2
       parameters:
-        - in: path
-          name: handleId
-          schema:
-            $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
-          required: true
+        - $ref: "../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId"
       responses:
         '204':
           description: The bulk request itself was correct and all elements have been

--- a/SubmodelRegistryServiceSpecification/V3.2_SSP-004.yaml
+++ b/SubmodelRegistryServiceSpecification/V3.2_SSP-004.yaml
@@ -30,6 +30,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
@@ -489,7 +489,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-001.yaml
@@ -1372,7 +1372,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:
@@ -1449,7 +1448,6 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   /submodels/{submodelIdentifier}/submodel-elements/{idShortPath}/invoke-async/$value:
     parameters:
-      - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/AssetAdministrationShellIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/SubmodelIdentifier'
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/IdShortPath'
     post:

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-002.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-002.yaml
@@ -250,7 +250,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel
@@ -312,7 +311,6 @@ paths:
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'
-        - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Date'
       responses:
         '200':
           description: Requested Submodel

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-005.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-005.yaml
@@ -30,6 +30,7 @@ paths:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Limit'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Cursor'
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/SubmodelRepositoryServiceSpecification/V3.2_SSP-007.yaml
+++ b/SubmodelRepositoryServiceSpecification/V3.2_SSP-007.yaml
@@ -25,9 +25,9 @@ paths:
       tags:
         - Submodel Repository API
       summary: Returns a specific Submodel valid at a specific point in time
-      operationId: GetSubmodelByIdAndDate
+      operationId: GetSubmodelVersionByIdAndDate
       x-semanticIds:
-        - https://admin-shell.io/aas/API/GetSubmodelByIdAndDate/3/2
+        - https://admin-shell.io/aas/API/GetSubmodelVersionByIdAndDate/3/2
       parameters:
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Level'
         - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/Extent'

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/annex/conformance-test-corpus.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/annex/conformance-test-corpus.adoc
@@ -41,7 +41,7 @@ Requirement: MUST | SHOULD
 
 | QL.parse.003
 | A query whose JSON parses but violates the JSON Schema MUST be rejected.
-| HTTP 422 with a JSON-pointer to the failing element.
+| HTTP 400 with a JSON-pointer to the failing element.
 
 | QL.field.001
 | `$aas#id` on an AAS Repository MUST resolve to AAS identifiers.
@@ -73,7 +73,7 @@ Requirement: MUST | SHOULD
 
 | QL.time.002
 | A `$timeVal` with invalid components (e.g. `25:00`) MUST be rejected by the schema.
-| HTTP 422.
+| HTTP 400.
 
 | QL.dt.001
 | `$dayOfWeek`, `$dayOfMonth`, `$month`, `$year` MUST accept a `Value` operand (not only a literal).
@@ -84,12 +84,12 @@ Requirement: MUST | SHOULD
 | Items whose supplementalSemanticIds contain the value are returned.
 
 | QL.logic.001
-| `$and` over an empty list MUST behave as `true` (identity of AND).
-| Equivalent to "match all".
+| `$and` with fewer than two operands MUST be rejected by the schema.
+| HTTP 400.
 
 | QL.logic.002
-| `$or` over an empty list MUST behave as `false` (identity of OR).
-| Equivalent to "match none".
+| `$or` with fewer than two operands MUST be rejected by the schema.
+| HTTP 400.
 |===
 
 [#ctc-http-api]
@@ -124,8 +124,8 @@ Requirement: MUST | SHOULD
 | Status `200` with binary body or `403`.
 
 | HTTP.query.001
-| `POST /query` MUST reject payloads that fail the Query JSON Schema with `422`.
-| Status `422`, JSON-pointer in body.
+| `POST /query` MUST reject payloads that fail the Query JSON Schema with `400`.
+| Status `400`, JSON-pointer in body.
 
 | HTTP.discovery.001
 | Discovery endpoints MUST honour the operation-to-RIGHT mapping of this spec (xref:annex/operation-to-right-mapping.adoc[]).
@@ -144,16 +144,16 @@ Requirement: MUST | SHOULD
 | Status `400 Bad Request`.
 
 | ERR.schema.001
-| A request body that is valid JSON but violates the schema MUST receive `422`.
-| Status `422 Unprocessable Entity`.
+| A request body that is valid JSON but violates the schema MUST receive `400`.
+| Status `400 Bad Request`.
 
 | ERR.cast.001
 | A runtime cast error (`num("abc")`) MUST NOT yield `500`; the item is excluded from the result.
 | Status `200`, item missing from response.
 
 | ERR.field.001
-| An unknown `<AttributeDeclaration>` MUST be rejected at schema level (`422`), not at runtime.
-| Status `422`.
+| An unknown `<AttributeDeclaration>` MUST be rejected at schema level (`400`), not at runtime.
+| Status `400`.
 
 | ERR.profile.001
 | A rule/query referencing a FieldIdentifier that is not applicable to the current profile is treated as "not applicable" (no match, no error).

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Marked the Query request body as required in all repository and registry query profiles, matching the mandatory query input in the interface definitions.
 * fix: Marked bulk DELETE request bodies as required and corrected the reusable `handleId` parameter references in the asynchronous registry bulk profiles.
 * fix: Corrected the AAS Service asynchronous invocation path from `/invoke-asnyc` to `/invoke-async` and removed undeclared `aasIdentifier` parameters from submodel operation routes.
 * fix: Changed JSON Schema validation from `oneOf` to `anyOf` where BNF grammar allows mixed inline and named groups in concatenation scenarios.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Corrected the AAS Service asynchronous invocation path from `/invoke-asnyc` to `/invoke-async` and removed undeclared `aasIdentifier` parameters from submodel operation routes.
 * fix: Changed JSON Schema validation from `oneOf` to `anyOf` where BNF grammar allows mixed inline and named groups in concatenation scenarios.
 * docs: Aligned prose tables in Query Language specification with BNF grammar and JSON Schema patterns for cast operators, field identifiers, and submodel element limitations.
 * docs: Added normative FieldIdentifier applicability table per profile to clarify which Query and Access Rule prefixes apply to specific service specification families.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Marked bulk DELETE request bodies as required and corrected the reusable `handleId` parameter references in the asynchronous registry bulk profiles.
 * fix: Corrected the AAS Service asynchronous invocation path from `/invoke-asnyc` to `/invoke-async` and removed undeclared `aasIdentifier` parameters from submodel operation routes.
 * fix: Changed JSON Schema validation from `oneOf` to `anyOf` where BNF grammar allows mixed inline and named groups in concatenation scenarios.
 * docs: Aligned prose tables in Query Language specification with BNF grammar and JSON Schema patterns for cast operators, field identifiers, and submodel element limitations.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Corrected `USEATTRIBUTES` in the access-rule JSON Schema to accept a list, so one ACL can reference multiple named attribute groups as defined by the BNF.
 * fix: Marked the Query request body as required in all repository and registry query profiles, matching the mandatory query input in the interface definitions.
 * fix: Marked bulk DELETE request bodies as required and corrected the reusable `handleId` parameter references in the asynchronous registry bulk profiles.
 * fix: Corrected the AAS Service asynchronous invocation path from `/invoke-asnyc` to `/invoke-async` and removed undeclared `aasIdentifier` parameters from submodel operation routes.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -728,13 +728,8 @@ In this case, the "/$value" path segment is added to the previously mentioned en
 == Asynchronous Invocation of an AASX File Upload
 The upload of an AASX file is only defined as an asynchronous operation in the current version of the specification.
 The expected behavior is therefore explained in detail.
-.Sequence for asynchronous AASX file upload
-[[aasx-upload-invocation]]
-[plantuml, aasx-upload-invocation, svg]
-....include::partial$diagrams/aasx-upload-invocation.puml[]
-....
 The client sends a POST request to the "/packages-async" endpoint with the AASX file in the request body.
-The server immediately responds with an Accepted (status code: 202) message containing the link to an endpoint where the client can fetch status information about his request (see <<aasx-upload-invocation>>).
+The server immediately responds with an Accepted (status code: 202) message containing the link to an endpoint where the client can fetch status information about his request.
 This status endpoint is located at "/packages-async/\{handleId}".
 In case the request is incorrect and the server already recognizes it, the server responds directly with the according status code, e.g. 400. If the server can only recognize the error during later processing and not at the time it receives the request, it responds with an Accepted (202) message at first. Hence, a received Accepted message does not guarantee the client that its request is valid in every case.
 If the server has not finished processing the request, the status endpoint responds with a message with the attribute "executionState" set to "Running".
@@ -878,4 +873,3 @@ h|Attribute h|Explanation h|Type h|Card.
 e|packageId a|File server specific package id |xref:specification/interfaces-payload.adoc#ShortIdType[ShortIdType] |1
 e|aasId a|Asset Administration Shell unique identifier |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.2/spec-metamodel/datatypes.html#Identifier[Identifier] |0..*
 |===
-

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/test/query/test_query_json_schema.py
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/test/query/test_query_json_schema.py
@@ -82,6 +82,18 @@ class QueryJsonSchemaValidationTest(unittest.TestCase):
 
         self.assert_valid(query)
 
+    def test_field_to_field_comparison_is_valid(self):
+        query = {
+            "$condition": {
+                "$eq": [
+                    {"$field": "$aas#idShort"},
+                    {"$field": "$aas#assetInformation.assetType"},
+                ]
+            }
+        }
+
+        self.assert_valid(query)
+
     def test_access_rule_payload_with_constrained_identifiers_is_valid(self):
         access_rules = {
             "DEFATTRIBUTES": [
@@ -125,6 +137,23 @@ class QueryJsonSchemaValidationTest(unittest.TestCase):
                     ],
                 }
             ],
+        }
+
+        self.assert_valid(access_rules)
+
+    def test_acl_can_reference_multiple_attribute_groups(self):
+        access_rules = {
+            "rules": [
+                {
+                    "ACL": {
+                        "USEATTRIBUTES": ["baseAttributes", "timeAttributes"],
+                        "RIGHTS": ["READ"],
+                        "ACCESS": "ALLOW",
+                    },
+                    "OBJECTS": [{"IDENTIFIABLE": '$aas("aas-id")'}],
+                    "FORMULA": {"$boolean": True},
+                }
+            ]
         }
 
         self.assert_valid(access_rules)

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/json-grammar.txt
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/json-grammar.txt
@@ -1,7 +1,18 @@
 
 <json> ::= <ws> (<query> | <all_access_permission_rules>) <ws>
 
-<query> ::=  "{" <ws> "\"Query\":" <ws> "{" <ws> "\"$condition\":" <ws> <logical_expression> <ws> ("," <ws> "\"$select\":" <ws> "id" <ws> )? <ws> "}" <ws> "}"
+<query> ::= "{" <ws>
+              "\"$condition\":" <ws> <logical_expression> <ws>
+              ("," <ws> "\"$select\":" <ws> "\"id\"" <ws>)?
+              ("," <ws> "\"$filters\":" <ws> <query_filter_array> <ws>)?
+            "}"
+
+<query_filter_array> ::= "[" <ws> <query_filter> <ws> ("," <ws> <query_filter> <ws>)* "]"
+
+<query_filter> ::= "{" <ws>
+                     "\"$fragment\":" <ws> <FragmentFieldIdentifier> <ws>
+                     "," <ws> "\"$condition\":" <ws> <logical_expression> <ws>
+                   "}"
 
 <logical_expression> ::= "{" <ws>
                           (
@@ -9,15 +20,15 @@
                               | "\"$or\":" <ws> <logical_expression_array>
                               | "\"$not\":" <ws> <logical_expression>
                               | "\"$match\":" <ws> <match_expression_array>
-                              | "\"$eq\":" <ws> <comparison_items>
-                              | "\"$ne\":" <ws> <comparison_items>
-                              | "\"$gt\":" <ws> <comparison_items>
-                              | "\"$ge\":" <ws> <comparison_items>
-                              | "\"$lt\":" <ws> <comparison_items>
-                              | "\"$le\":" <ws> <comparison_items>
+                              | "\"$eq\":" <ws> <equality_comparison_items>
+                              | "\"$ne\":" <ws> <equality_comparison_items>
+                              | "\"$gt\":" <ws> <ordered_comparison_items>
+                              | "\"$ge\":" <ws> <ordered_comparison_items>
+                              | "\"$lt\":" <ws> <ordered_comparison_items>
+                              | "\"$le\":" <ws> <ordered_comparison_items>
                               | "\"$contains\":" <ws> <string_items>
-                              | "\"$starts_with\":" <ws> <string_items>
-                              | "\"$ends_with\":" <ws> <string_items>
+                              | "\"$starts-with\":" <ws> <string_items>
+                              | "\"$ends-with\":" <ws> <string_items>
                               | "\"$regex\":" <ws> <string_items>
                               | "\"$boolean\":" <ws> <boolean> <ws>
                           )
@@ -26,47 +37,64 @@
 <match_expression> ::= "{" <ws>
                           (
                               "\"$match\":" <ws> <match_expression_array>
-                              | "\"$eq\":" <ws> <comparison_items>
-                              | "\"$ne\":" <ws> <comparison_items>
-                              | "\"$gt\":" <ws> <comparison_items>
-                              | "\"$ge\":" <ws> <comparison_items>
-                              | "\"$lt\":" <ws> <comparison_items>
-                              | "\"$le\":" <ws> <comparison_items>
+                              | "\"$eq\":" <ws> <equality_comparison_items>
+                              | "\"$ne\":" <ws> <equality_comparison_items>
+                              | "\"$gt\":" <ws> <ordered_comparison_items>
+                              | "\"$ge\":" <ws> <ordered_comparison_items>
+                              | "\"$lt\":" <ws> <ordered_comparison_items>
+                              | "\"$le\":" <ws> <ordered_comparison_items>
                               | "\"$contains\":" <ws> <string_items>
-                              | "\"$starts_with\":" <ws> <string_items>
-                              | "\"$ends_with\":" <ws> <string_items>
+                              | "\"$starts-with\":" <ws> <string_items>
+                              | "\"$ends-with\":" <ws> <string_items>
                               | "\"$regex\":" <ws> <string_items>
-                              | "\"$boolean\":" <ws> <boolean>
                           )
                           <ws> "}"
 
-<comparison_items> ::= "[" <ws> <value> <ws> "," <ws> <value> <ws> "]"
+<equality_comparison_items> ::= <string_items> | <numerical_comparison_items> | <hex_comparison_items> | <bool_comparison_items> | <date_time_comparison_items> | <time_comparison_items>
+
+<ordered_comparison_items> ::= <string_items> | <numerical_comparison_items> | <hex_comparison_items> | <date_time_comparison_items> | <time_comparison_items>
 
 <string_items> ::= "[" <ws> <string_value> <ws> "," <ws> <string_value> <ws> "]"
+
+<numerical_comparison_items> ::= "[" <ws> (<numerical_operand> | <field_operand>) <ws> "," <ws> (<numerical_operand> | <field_operand>) <ws> "]"
+
+<hex_comparison_items> ::= "[" <ws> (<hex_operand> | <field_operand>) <ws> "," <ws> (<hex_operand> | <field_operand>) <ws> "]"
+
+<bool_comparison_items> ::= "[" <ws> (<bool_operand> | <field_operand>) <ws> "," <ws> (<bool_operand> | <field_operand>) <ws> "]"
+
+<date_time_comparison_items> ::= "[" <ws> (<date_time_operand> | <field_operand>) <ws> "," <ws> (<date_time_operand> | <field_operand>) <ws> "]"
+
+<time_comparison_items> ::= "[" <ws> (<time_operand> | <field_operand>) <ws> "," <ws> (<time_operand> | <field_operand>) <ws> "]"
 
 <logical_expression_array> ::= "[" <ws> <logical_expression> <ws> ( "," <ws> <logical_expression> <ws>)* "]"
 <match_expression_array> ::= "[" <ws> <match_expression> <ws> ( "," <ws> <match_expression> <ws>)* "]"
 
-<value> ::= "{" <ws>
-                   (
-                       "\"$field\":" <ws> <FieldIdentifier>
-                       | "\"$strVal\":" <ws> <StringLiteral>
-                       | "\"$attribute\":" <ws> <attribute>
-                       | "\"$numVal\":" <ws> <NumericalLiteral>
-                       | "\"$hexVal\":" <ws> <HexLiteral>
-                       | "\"$dateTimeVal\":" <ws> <DateTimeLiteral>
-                       | "\"$timeVal\":" <ws> <TimeLiteral>
-                       | "\"$boolean\":" <ws> <boolean>
-                       | "\"$numCast\":" <ws> <value>
-                       | "\"$hexCast\":" <ws> <value>
-                       | "\"$boolCast\":" <ws> <value>
-                       | "\"$dateTimeCast\":" <ws> <value>
-                       | "\"$timeCast\":" <ws> <value>
-                       | "\"$dayOfWeek\":" <ws> <value>
-                       | "\"$dayOfMonth\":" <ws> <value>
-                       | "\"$month\":" <ws> <value>
-                       | "\"$year\":" <ws> <value>
-                   )
+<value> ::= <string_value> | <numerical_operand> | <hex_operand> | <bool_operand> | <date_time_operand> | <time_operand>
+
+<field_operand> ::= "{" <ws> "\"$field\":" <ws> <FieldIdentifier> <ws> "}"
+
+<numerical_operand> ::= "{" <ws>
+                          ("\"$numVal\":" <ws> <NumericalLiteral>
+                           | "\"$numCast\":" <ws> <value>
+                           | "\"$dayOfWeek\":" <ws> <date_time_operand>
+                           | "\"$dayOfMonth\":" <ws> <date_time_operand>
+                           | "\"$month\":" <ws> <date_time_operand>
+                           | "\"$year\":" <ws> <date_time_operand>)
+                        <ws> "}"
+
+<hex_operand> ::= "{" <ws> ("\"$hexVal\":" <ws> <HexLiteral> | "\"$hexCast\":" <ws> <value>) <ws> "}"
+
+<bool_operand> ::= "{" <ws> ("\"$boolean\":" <ws> <boolean> | "\"$boolCast\":" <ws> <value>) <ws> "}"
+
+<date_time_operand> ::= "{" <ws>
+                          ("\"$dateTimeVal\":" <ws> <DateTimeLiteral>
+                           | "\"$dateTimeCast\":" <ws> <string_value>
+                           | "\"$attribute\":" <ws> <attribute>)
+                        <ws> "}"
+
+<time_operand> ::= "{" <ws>
+                     ("\"$timeVal\":" <ws> <TimeLiteral>
+                      | "\"$timeCast\":" <ws> (<string_value> | <date_time_operand>))
                    <ws> "}"
 
 
@@ -75,8 +103,8 @@
             | "\"$numCast\":" <ws> <value>
             | "\"$hexCast\":" <ws> <value>
             | "\"$boolCast\":" <ws> <value>
-            | "\"$dateTimeCast\":" <ws> <value>
-            | "\"$timeCast\":" <ws> <value>
+            | "\"$dateTimeCast\":" <ws> <string_value>
+            | "\"$timeCast\":" <ws> (<string_value> | <date_time_operand>)
           )
 
 <string_value> ::= "{" <ws>
@@ -229,6 +257,22 @@
 <NumericalLiteral> ::= ( "+" | "-" )? ( [0-9]+ ( "." [0-9]* )? | "." [0-9]+ ) ( ( "e" | "E" )? [0-9]+ )
 <HexLiteral> ::= "\"" "16#" ( [0-9] | [A-F] )+ "\""
 <BoolLiteral> ::= "true" | "false"
+
+<FragmentFieldIdentifier> ::= "\"" ( <FieldIdentifierAASFragment> | <FieldIdentifierSMFragment> | <FieldIdentifierSMEFragment> | <FieldIdentifierCDFragment> | <FieldIdentifierAasDescriptorFragment> | <FieldIdentifierSmDescriptorFragment> ) "\""
+<FieldIdentifierAASFragment> ::= "$aas#" ( "idShort" | "assetInformation.assetType" | "assetInformation.globalAssetId" | "assetInformation." <SpecificAssetIdsClauseFragment> | <SubmodelsClauseFragment> )
+<FieldIdentifierSMFragment> ::= "$sm#" ( <SemanticIdClauseFragment> | <SupplementalSemanticIdClauseFragment> | "idShort" )
+<FieldIdentifierSMEFragment> ::= "$sme" ( "." <idShortPath> )? ( "#" ( <SemanticIdClauseFragment> | <SupplementalSemanticIdClauseFragment> | "idShort" | "value" | "valueType" | "language" ) )?
+<FieldIdentifierCDFragment> ::= "$cd#idShort"
+<FieldIdentifierAasDescriptorFragment> ::= "$aasdesc#" ( "idShort" | "description" | "displayName" | "extension" | "administration" | "assetKind" | "assetType" | "globalAssetId" | <SpecificAssetIdsClauseFragment> | <EndpointClauseFragment> | <SubmodelDescriptorsClauseFragment> )
+<FieldIdentifierSmDescriptorFragment> ::= "$smdesc#" <SmDescriptorClauseFragment>
+<SpecificAssetIdsClauseFragment> ::= "specificAssetIds" ( "[" <ArrayIndex>? "]" ( ".externalSubjectId" ( "." <ReferenceClauseFragment> )? )? )?
+<SubmodelsClauseFragment> ::= "submodels" ( "[" <ArrayIndex>? "]" ( "." <ReferenceClauseFragment> )? )?
+<SubmodelDescriptorsClauseFragment> ::= "submodelDescriptors" ( "[" <ArrayIndex>? "]" ( "." <SmDescriptorClauseFragment> )? )?
+<SmDescriptorClauseFragment> ::= <SemanticIdClauseFragment> | <SupplementalSemanticIdClauseFragment> | "idShort" | <EndpointClauseFragment>
+<EndpointClauseFragment> ::= "endpoints" ( "[" <ArrayIndex>? "]" )?
+<SemanticIdClauseFragment> ::= "semanticId" ( "." <ReferenceClauseFragment> )?
+<SupplementalSemanticIdClauseFragment> ::= "supplementalSemanticIds" ( "[" <ArrayIndex>? "]" ( "." <ReferenceClauseFragment> )? )?
+<ReferenceClauseFragment> ::= "keys" ( "[" <ArrayIndex>? "]" )?
 
 <FieldIdentifier> ::= "\"" ( <FieldIdentifierAAS> | <FieldIdentifierSM> | <FieldIdentifierSME> | <FieldIdentifierCD> | <FieldIdentifierAasDescriptor> | <FieldIdentifierSmDescriptor> ) "\""
 <FieldIdentifierAAS> ::= "$aas#" ( "idShort" | "id" | "assetInformation.assetKind" | "assetInformation.assetType" | "assetInformation.globalAssetId" | "assetInformation." <SpecificAssetIdsClause> | "submodels" ( "[" <ArrayIndex>? "]" ) ("." <ReferenceClause>)? )

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
@@ -853,8 +853,8 @@ h| JSON Schema h| Grammar h| Comment
 | $numCast | <castToNumerical> | any Value can be used as input
 | $hexCast | <castToHex> | any Value can be used as input
 | $boolCast | <castToBool> | any Value can be used as input
-| $dateTimeCast | <castToDateTime> | any Value can be used as input
-| $timeCast | <castToTime> | any Value can be used as input
+| $dateTimeCast | <castToDateTime> | string operands can be used as input
+| $timeCast | <castToTime> | string or DateTime operands can be used as input
 | $dayOfWeek | <dateTimeToNum> | extract day of week from DateTime; needed for Security Access Rules
 | $dayOfMonth | <dateTimeToNum> | extract day of month from DateTime; needed for Security Access Rules
 | $month | <dateTimeToNum> | extract month from DateTime; needed for Security Access Rules

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/query-language.adoc
@@ -730,9 +730,9 @@ $sm#semanticId $eq
   "https://admin-shell.io/idta/nameplate/3/0/Nameplate"
 $filters
   $fragment   $sme#value
-  $condition  $sm#semanticId.keys[].value $eq "https://example.com/semantic-id/hide-value"
+  $condition  $not ($sm#semanticId.keys[].value $eq "https://example.com/semantic-id/hide-value")
   $fragment   $sm#semanticId.keys[]
-  $condition  $sm#semanticId.keys[].value $eq "https://example.com/semantic-id/hide-value"
+  $condition  $not ($sm#semanticId.keys[].value $eq "https://example.com/semantic-id/hide-value")
 ----
 a|
 [source,json]
@@ -752,27 +752,31 @@ a|
     {
       "$fragment": "$sme#value",
       "$condition": {
-        "$eq": [
-          {
-            "$field": "$sm#semanticId.keys[].value"
-          },
-          {
-            "$strVal": "https://example.com/semantic-id/hide-value"
-          }
-        ]
+        "$not": {
+          "$eq": [
+            {
+              "$field": "$sm#semanticId.keys[].value"
+            },
+            {
+              "$strVal": "https://example.com/semantic-id/hide-value"
+            }
+          ]
+        }
       }
     },
     {
       "$fragment": "$sm#semanticId.keys[]",
       "$condition": {
-        "$eq": [
-          {
-            "$field": "$sm#semanticId.keys[].value"
-          },
-          {
-            "$strVal": "https://example.com/semantic-id/hide-value"
-          }
-        ]
+        "$not": {
+          "$eq": [
+            {
+              "$field": "$sm#semanticId.keys[].value"
+            },
+            {
+              "$strVal": "https://example.com/semantic-id/hide-value"
+            }
+          ]
+        }
       }
     }
   ]

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
@@ -512,6 +512,19 @@
               "$ref": "#/definitions/stringValue"
             }
           ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
         }
       ]
     },
@@ -1093,7 +1106,10 @@
           }
         },
         "USEATTRIBUTES": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "RIGHTS": {
           "type": "array",

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/schema.adoc
@@ -49,11 +49,207 @@
     },
     "dateTimeLiteralPattern": {
       "type": "string",
-      "format": "date-time"
+      "pattern": "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?$"
     },
     "timeLiteralPattern": {
       "type": "string",
-      "pattern": "^[0-9][0-9]:[0-9][0-9](:[0-9][0-9])?(\\.[0-9]+)?(Z|[+-][0-9][0-9]:[0-9][0-9])?$"
+      "pattern": "^(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?$"
+    },
+    "dateTimeAttributeItem": {
+      "type": "object",
+      "properties": {
+        "GLOBAL": {
+          "type": "string",
+          "enum": [
+            "LOCALNOW",
+            "UTCNOW",
+            "CLIENTNOW"
+          ]
+        }
+      },
+      "required": [
+        "GLOBAL"
+      ],
+      "additionalProperties": false
+    },
+    "dateTimeOperand": {
+      "type": "object",
+      "properties": {
+        "$dateTimeVal": {
+          "$ref": "#/definitions/dateTimeLiteralPattern"
+        },
+        "$dateTimeCast": {
+          "$ref": "#/definitions/stringValue"
+        },
+        "$attribute": {
+          "$ref": "#/definitions/dateTimeAttributeItem"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$dateTimeVal"
+          ]
+        },
+        {
+          "required": [
+            "$dateTimeCast"
+          ]
+        },
+        {
+          "required": [
+            "$attribute"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "fieldOperand": {
+      "type": "object",
+      "properties": {
+        "$field": {
+          "$ref": "#/definitions/FieldIdentifier"
+        }
+      },
+      "required": [
+        "$field"
+      ],
+      "additionalProperties": false
+    },
+    "numericalOperand": {
+      "type": "object",
+      "properties": {
+        "$numVal": {
+          "type": "number"
+        },
+        "$numCast": {
+          "$ref": "#/definitions/Value"
+        },
+        "$dayOfWeek": {
+          "$ref": "#/definitions/dateTimeOperand"
+        },
+        "$dayOfMonth": {
+          "$ref": "#/definitions/dateTimeOperand"
+        },
+        "$month": {
+          "$ref": "#/definitions/dateTimeOperand"
+        },
+        "$year": {
+          "$ref": "#/definitions/dateTimeOperand"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$numVal"
+          ]
+        },
+        {
+          "required": [
+            "$numCast"
+          ]
+        },
+        {
+          "required": [
+            "$dayOfWeek"
+          ]
+        },
+        {
+          "required": [
+            "$dayOfMonth"
+          ]
+        },
+        {
+          "required": [
+            "$month"
+          ]
+        },
+        {
+          "required": [
+            "$year"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "hexOperand": {
+      "type": "object",
+      "properties": {
+        "$hexVal": {
+          "$ref": "#/definitions/hexLiteralPattern"
+        },
+        "$hexCast": {
+          "$ref": "#/definitions/Value"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$hexVal"
+          ]
+        },
+        {
+          "required": [
+            "$hexCast"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "boolOperand": {
+      "type": "object",
+      "properties": {
+        "$boolean": {
+          "type": "boolean"
+        },
+        "$boolCast": {
+          "$ref": "#/definitions/Value"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$boolean"
+          ]
+        },
+        {
+          "required": [
+            "$boolCast"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "timeOperand": {
+      "type": "object",
+      "properties": {
+        "$timeVal": {
+          "$ref": "#/definitions/timeLiteralPattern"
+        },
+        "$timeCast": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/stringValue"
+            },
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            }
+          ]
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$timeVal"
+          ]
+        },
+        {
+          "required": [
+            "$timeCast"
+          ]
+        }
+      ],
+      "additionalProperties": false
     },
     "Value": {
       "type": "object",
@@ -95,50 +291,29 @@
           "$ref": "#/definitions/Value"
         },
         "$dateTimeCast": {
-          "$ref": "#/definitions/Value"
+          "$ref": "#/definitions/stringValue"
         },
         "$timeCast": {
-          "$ref": "#/definitions/Value"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/stringValue"
+            },
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            }
+          ]
         },
         "$dayOfWeek": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         },
         "$dayOfMonth": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         },
         "$month": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         },
         "$year": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/dateTimeLiteralPattern"
-            },
-            {
-              "$ref": "#/definitions/attributeItem"
-            }
-          ]
+          "$ref": "#/definitions/dateTimeOperand"
         }
       },
       "oneOf": [
@@ -275,21 +450,301 @@
       ],
       "additionalProperties": false
     },
+    "stringNonFieldValue": {
+      "type": "object",
+      "properties": {
+        "$strVal": {
+          "$ref": "#/definitions/standardString"
+        },
+        "$strCast": {
+          "$ref": "#/definitions/Value"
+        },
+        "$attribute": {
+          "$ref": "#/definitions/attributeItem"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "$strVal"
+          ]
+        },
+        {
+          "required": [
+            "$strCast"
+          ]
+        },
+        {
+          "required": [
+            "$attribute"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
     "comparisonItems": {
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 2,
-      "items": {
-        "$ref": "#/definitions/Value"
-      }
+      "$ref": "#/definitions/equalityComparisonItems"
     },
     "stringItems": {
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 2,
-      "items": {
-        "$ref": "#/definitions/stringValue"
-      }
+      "anyOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/stringValue"
+            },
+            {
+              "$ref": "#/definitions/stringNonFieldValue"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/stringNonFieldValue"
+            },
+            {
+              "$ref": "#/definitions/stringValue"
+            }
+          ]
+        }
+      ]
+    },
+    "numericalComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/numericalOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/numericalOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/numericalOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "hexComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/hexOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/hexOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/hexOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "boolComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/boolOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/boolOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/boolOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "dateTimeComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/dateTimeOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/dateTimeOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "timeComparisonItems": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "$ref": "#/definitions/timeOperand"
+          }
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/timeOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/timeOperand"
+            }
+          ]
+        }
+      ]
+    },
+    "equalityComparisonItems": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/stringItems"
+        },
+        {
+          "$ref": "#/definitions/numericalComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/hexComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/boolComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/dateTimeComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/timeComparisonItems"
+        }
+      ]
+    },
+    "orderedComparisonItems": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/stringItems"
+        },
+        {
+          "$ref": "#/definitions/numericalComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/hexComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/dateTimeComparisonItems"
+        },
+        {
+          "$ref": "#/definitions/timeComparisonItems"
+        }
+      ]
     },
     "matchExpression": {
       "type": "object",
@@ -302,22 +757,22 @@
           }
         },
         "$eq": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$ne": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$gt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$ge": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$lt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$le": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$contains": {
           "$ref": "#/definitions/stringItems"
@@ -330,9 +785,6 @@
         },
         "$regex": {
           "$ref": "#/definitions/stringItems"
-        },
-        "$boolean": {
-          "type": "boolean"
         }
       },
       "oneOf": [
@@ -388,11 +840,6 @@
         },
         {
           "required": [
-            "$boolean"
-          ]
-        },
-        {
-          "required": [
             "$match"
           ]
         }
@@ -427,22 +874,22 @@
           "$ref": "#/definitions/logicalExpression"
         },
         "$eq": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$ne": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/equalityComparisonItems"
         },
         "$gt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$ge": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$lt": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$le": {
-          "$ref": "#/definitions/comparisonItems"
+          "$ref": "#/definitions/orderedComparisonItems"
         },
         "$contains": {
           "$ref": "#/definitions/stringItems"

--- a/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
+++ b/documentation/IDTA-01002-3/modules/ROOT/partials/query-json-schema.json
@@ -511,6 +511,19 @@
               "$ref": "#/definitions/stringValue"
             }
           ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "$ref": "#/definitions/fieldOperand"
+            },
+            {
+              "$ref": "#/definitions/fieldOperand"
+            }
+          ]
         }
       ]
     },
@@ -1092,7 +1105,10 @@
           }
         },
         "USEATTRIBUTES": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "RIGHTS": {
           "type": "array",


### PR DESCRIPTION
The HTTP chapter tried to include an AASX upload diagram that does not exist and placed the include on the literal-block delimiter line. AsciiDoc therefore treated the following AASX and bulk sections as literal content. The AASX profile also showed its `ServiceDescription` response as a scalar URI although the schema requires an object with a `profiles` array.

This change removes the unavailable diagram block while retaining the complete prose description, and replaces the response example with an object that matches `ServiceDescription`.

### Validation

- Verified that the broken AASX diagram include and anchor are gone
- `openapi-spec-validator` passes for the AASX async profile
- Parsed and checked the ServiceDescription example shape
- `python tools/validate_spec_artifacts.py`
- `git diff --check`

### Merge order

Depends on #654. Merge #646 through #654 before this PR.