### PR TITLE
Fix the AASX upload multipart contract

### DIFF
--- a/AasxFileServerServiceSpecification/V3.2_SSP-001.yaml
+++ b/AasxFileServerServiceSpecification/V3.2_SSP-001.yaml
@@ -75,8 +75,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package
@@ -168,8 +171,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package

--- a/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
+++ b/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
@@ -41,8 +41,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7668,8 +7668,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package
@@ -7761,8 +7764,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package
@@ -7835,8 +7841,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Required the binary `file` part for AASX package uploads and removed the redundant `fileName` multipart field; an optional source filename is conveyed by the standard `filename` parameter of the file part.
 * fix: Corrected `USEATTRIBUTES` in the access-rule JSON Schema to accept a list, so one ACL can reference multiple named attribute groups as defined by the BNF.
 * fix: Marked the Query request body as required in all repository and registry query profiles, matching the mandatory query input in the interface definitions.
 * fix: Marked bulk DELETE request bodies as required and corrected the reusable `handleId` parameter references in the asynchronous registry bulk profiles.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -759,7 +759,6 @@ Servers may simply store the AASX files with their related given aasIds.
 
 |no |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.2/spec-metamodel/datatypes.html#Identifier[Identifier] |0..*
 e|file |New AASX package |yes |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01005/v3.1/index.html[AASX package] |1
-e|filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 e|statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 e|packageId |New Package ID |yes |string |1
@@ -789,7 +788,6 @@ Servers may simply store the AASX files with their related given aasIds.
 
 |no |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.2/spec-metamodel/datatypes.html#Identifier[Identifier] |0..*
 e|file |New AASX package |yes |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01005/v3.1/index.html[AASX package] |1
-e|filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 e|statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -822,7 +820,6 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAsyncAASXPackage/3/2`
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
 e|file |New AASX package |yes |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01005/v3.1/index.html[AASX package] |1
-e|filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 e|statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 e|payload |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes | xref:specification/interfaces-payload.adoc#OperationHandle[OperationHandle] |1


### PR DESCRIPTION
The AASX upload request bodies were mandatory, but their multipart schemas did not require the binary file. A request with an empty object therefore satisfied the OpenAPI contract even though the server had nothing to store. This defect was already present in V3.1.3, so the correction is recorded in the V3.2 changelog.

The previous version of this PR tried to solve that by requiring a separate `fileName` form field as well. That was the wrong multipart mapping. RFC 7578 carries an optional source filename in the `filename` parameter of the file part's `Content-Disposition` header; a separate OpenAPI property would describe a second form part. Part 5 defines the `.aasx` extension and media type, but does not give the outer filename additional semantics. Part 2 still returns a filename when downloading a package, but the server can derive or generate that independently.

This change requires only the binary `file` part for synchronous create/update uploads and the asynchronous upload profile. It removes `filename` from the abstract upload inputs, documents the standard multipart filename mechanism on the file part, and keeps the combined API aligned.

### Validation

- `openapi-spec-validator` passes for both AASX profiles and the combined API
- Parsed all six profile/combined upload schemas and verified that only `file` is required
- `python3 tools/validate_spec_artifacts.py`
- `git diff --check`
- Cross-checked RFC 7578, OpenAPI 3.0 multipart encoding, Part 2, and Part 5

### Merge order

Depends on #655. Merge #646 through #655 before this PR.
