### PR TITLE
Align the AASX async contract

### DIFF
--- a/AasxFileServerServiceSpecification/V3.2_SSP-001.yaml
+++ b/AasxFileServerServiceSpecification/V3.2_SSP-001.yaml
@@ -75,8 +75,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package
@@ -168,8 +171,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package

--- a/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
+++ b/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
@@ -41,8 +41,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package

--- a/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
+++ b/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
@@ -52,7 +52,16 @@ paths:
         required: true
       responses:
         '202':
-          $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/accepted'
+          description: The server has accepted the request.
+          headers:
+            Location:
+              description: The URL where the client can request the current status of the operation.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/OperationHandle'
         '400':
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/bad-request'
         '401':
@@ -66,7 +75,7 @@ paths:
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   
-  /packages-async/status/{handleId}:
+  /packages-async/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -97,7 +106,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /packages-async/results/{handleId}:
+  /packages-async/result/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -113,7 +122,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/BaseOperationResult'
+                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/OperationResult'
         '400':
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/bad-request'
         '401':

--- a/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
+++ b/AasxFileServerServiceSpecification/V3.2_SSP-002.yaml
@@ -75,7 +75,7 @@ paths:
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
   
-  /packages-async/{handleId}:
+  /packages-async/status/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -122,7 +122,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/OperationResult'
+                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/BaseOperationResult'
         '400':
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/bad-request'
         '401':

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7874,7 +7874,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /packages-async/{handleId}:
+  /packages-async/status/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -7921,7 +7921,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/OperationResult'
+                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/BaseOperationResult'
         '400':
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/bad-request'
         '401':

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7852,7 +7852,16 @@ paths:
         required: true
       responses:
         '202':
-          $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/accepted'
+          description: The server has accepted the request.
+          headers:
+            Location:
+              description: The URL where the client can request the current status of the operation.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/OperationHandle'
         '400':
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/bad-request'
         '401':
@@ -7865,7 +7874,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /packages-async/status/{handleId}:
+  /packages-async/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -7896,7 +7905,7 @@ paths:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/internal-server-error'
         default:
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/default'
-  /packages-async/results/{handleId}:
+  /packages-async/result/{handleId}:
     parameters:
       - $ref: '../Part2-API-Schemas/openapi.yaml#/components/parameters/HandleId'
     get:
@@ -7912,7 +7921,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/BaseOperationResult'
+                $ref: '../Part2-API-Schemas/openapi.yaml#/components/schemas/OperationResult'
         '400':
           $ref: '../Part2-API-Schemas/openapi.yaml#/components/responses/bad-request'
         '401':

--- a/Entire-API-Collection/V3.2.yaml
+++ b/Entire-API-Collection/V3.2.yaml
@@ -7668,8 +7668,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package
@@ -7761,8 +7764,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package
@@ -7835,8 +7841,11 @@ paths:
                 file:
                   type: string
                   format: binary
-                fileName:
-                  type: string
+                  description: >-
+                    AASX package. A source filename, if supplied, is conveyed in the
+                    `filename` parameter of this part's `Content-Disposition` header.
+              required:
+                - file
             encoding:
               file:
                 contentType: application/asset-administration-shell-package

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/changelog.adoc
@@ -28,6 +28,7 @@ This section also includes an overview of how to expose the DPP interactions thr
 
 Minor Changes:
 
+* fix: Required the binary `file` part for AASX package uploads and removed the redundant `fileName` multipart field; an optional source filename is conveyed by the standard `filename` parameter of the file part.
 * fix: Corrected `USEATTRIBUTES` in the access-rule JSON Schema to accept a list, so one ACL can reference multiple named attribute groups as defined by the BNF.
 * fix: Marked the Query request body as required in all repository and registry query profiles, matching the mandatory query input in the interface definitions.
 * fix: Marked bulk DELETE request bodies as required and corrected the reusable `handleId` parameter references in the asynchronous registry bulk profiles.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -604,7 +604,7 @@ Pagination
 |PutAASXByPackageId |PUT |/packages/\{packageId} |base64url-encoded identifier
 |DeleteAASXByPackageId |DELETE |/packages/\{packageId} |base64url-encoded identifier
 |PostAsyncAASXPackage |POST |/packages-async |
-|GetAasxAsyncStatus |GET |/packages-async/\{handleId} |
+|GetAasxAsyncStatus |GET |/packages-async/status/\{handleId} |
 |GetAasxAsyncResult |GET |/packages-async/result/\{handleId} |
 
 4+h|Serialization Interface

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -729,7 +729,7 @@ In this case, the "/$value" path segment is added to the previously mentioned en
 The upload of an AASX file is only defined as an asynchronous operation in the current version of the specification.
 The expected behavior is therefore explained in detail.
 The client sends a POST request to the "/packages-async" endpoint with the AASX file in the request body.
-The server immediately responds with an Accepted (status code: 202) message containing the link to an endpoint where the client can fetch status information about his request.
+The server immediately responds with an Accepted (status code: 202) message containing an OperationHandle in the response body and the link to the status endpoint in the Location response header.
 This status endpoint is located at "/packages-async/\{handleId}".
 In case the request is incorrect and the server already recognizes it, the server responds directly with the according status code, e.g. 400. If the server can only recognize the error during later processing and not at the time it receives the request, it responds with an Accepted (202) message at first. Hence, a received Accepted message does not guarantee the client that its request is valid in every case.
 If the server has not finished processing the request, the status endpoint responds with a message with the attribute "executionState" set to "Running".

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/http-rest-api/http-rest-api.adoc
@@ -730,7 +730,7 @@ The upload of an AASX file is only defined as an asynchronous operation in the c
 The expected behavior is therefore explained in detail.
 The client sends a POST request to the "/packages-async" endpoint with the AASX file in the request body.
 The server immediately responds with an Accepted (status code: 202) message containing an OperationHandle in the response body and the link to the status endpoint in the Location response header.
-This status endpoint is located at "/packages-async/\{handleId}".
+This status endpoint is located at "/packages-async/status/\{handleId}".
 In case the request is incorrect and the server already recognizes it, the server responds directly with the according status code, e.g. 400. If the server can only recognize the error during later processing and not at the time it receives the request, it responds with an Accepted (202) message at first. Hence, a received Accepted message does not guarantee the client that its request is valid in every case.
 If the server has not finished processing the request, the status endpoint responds with a message with the attribute "executionState" set to "Running".
 As soon as the processing is finished, the status endpoints deliver a Found (HTTP status code 302) response with the location of the result in the Location response header.

--- a/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
+++ b/documentation/IDTA-01002-3/modules/ROOT/pages/specification/interfaces.adoc
@@ -759,7 +759,6 @@ Servers may simply store the AASX files with their related given aasIds.
 
 |no |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.2/spec-metamodel/datatypes.html#Identifier[Identifier] |0..*
 e|file |New AASX package |yes |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01005/v3.1/index.html[AASX package] |1
-e|filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 e|statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 e|packageId |New Package ID |yes |string |1
@@ -789,7 +788,6 @@ Servers may simply store the AASX files with their related given aasIds.
 
 |no |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01001/v3.2/spec-metamodel/datatypes.html#Identifier[Identifier] |0..*
 e|file |New AASX package |yes |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01005/v3.1/index.html[AASX package] |1
-e|filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 e|statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 |===
@@ -822,7 +820,6 @@ h|semanticId 4+|`\https://admin-shell.io/aas/API/PostAsyncAASXPackage/3/2`
 h|Name h|Description h|Mand. h|Type h|Card.
 5+h|Input Parameter
 e|file |New AASX package |yes |link:https://industrialdigitaltwin.io/aas-specifications/IDTA-01005/v3.1/index.html[AASX package] |1
-e|filename |Filename of the AASX package |yes |string |1
 5+h|Output Parameter
 e|statusCode |Status code |yes |xref:specification/interfaces-payload.adoc#StatusCode[StatusCode] |1
 e|payload |The returned handle of an operation’s asynchronous invocation used to request the current state of the operation’s execution |yes | xref:specification/interfaces-payload.adoc#OperationHandle[OperationHandle] |1


### PR DESCRIPTION
The asynchronous AASX OpenAPI profile used different status and result routes from the HTTP/REST specification. Its accepted response exposed only a Location header even though the abstract interface requires an OperationHandle, and the result endpoint returned BaseOperationResult instead of the declared OperationResult. Clients generated from the OpenAPI contract would therefore call the wrong routes and could not rely on the documented response payloads.

This change aligns the profile and combined API with the canonical `/packages-async/{handleId}` and `/packages-async/result/{handleId}` routes. The 202 response now includes both the status Location and an OperationHandle body, while the final 200 response uses OperationResult. The explanatory HTTP text now states both accepted-response outputs. These operations are new in V3.2 and are already recorded as such in the changelog.

### Validation

- `openapi-spec-validator AasxFileServerServiceSpecification/V3.2_SSP-002.yaml`
- `openapi-spec-validator Entire-API-Collection/V3.2.yaml`
- `python tools/validate_spec_artifacts.py`
- `git diff --check`

### Merge order

Depends on #656. Merge #646 through #656 before this PR.